### PR TITLE
Align license terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ Compatible with macOS and Windows
 
 ## 🛡️ License
 
-Non-commercial academic use only.  
-To collaborate, adapt, or extend, please contact the **Tykocki Lab**.
+VasoAnalyzer is released under the terms of the MIT License. See
+[`docs/LICENSE.txt`](docs/LICENSE.txt) for the full license text.
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify that VasoAnalyzer uses the MIT License

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847900ac4748326997593a2dce5b415