### PR TITLE
Fix save_project extension

### DIFF
--- a/src/vasoanalyzer/gui.py
+++ b/src/vasoanalyzer/gui.py
@@ -1170,6 +1170,8 @@ class VasoAnalyzerApp(QMainWindow):
         path, _ = QFileDialog.getSaveFileName(self, "Save Project", "", "Vaso Projects (*.vaso)")
         if not path:
             return
+        if not path.endswith(".vaso"):
+            path += ".vaso"
         try:
             with h5py.File(path, "w") as f:
                 grp = f.create_group("trace")


### PR DESCRIPTION
## Summary
- ensure `save_project()` always appends `.vaso`

## Testing
- `python -m py_compile src/vasoanalyzer/gui.py`

------
https://chatgpt.com/codex/tasks/task_e_6848bbe83a448326a0b32ed3d78ce796