### PR TITLE
Fix plot style editor call for dual view

### DIFF
--- a/src/vasoanalyzer/dual_view_panel.py
+++ b/src/vasoanalyzer/dual_view_panel.py
@@ -307,46 +307,15 @@ class DataViewPanel(QWidget):
             self.scroll_slider.hide()
 
     def _open_plot_style(self):
-        # Open main plot style dialog and apply to this panel
-        from PyQt5.QtWidgets import QDialog
-        from vasoanalyzer.gui import PlotStyleDialog
-        dialog = PlotStyleDialog(self)
-
-        def capture_current_style():
-            style = {
-                "axis_font_size": self.ax.xaxis.label.get_fontsize(),
-                "axis_font_family": self.ax.xaxis.label.get_fontname(),
-                "axis_bold": str(self.ax.xaxis.label.get_fontweight()).lower() == "bold",
-                "axis_italic": self.ax.xaxis.label.get_fontstyle() == "italic",
-                "tick_font_size": self.ax.xaxis.get_ticklabels()[0].get_fontsize()
-                if self.ax.xaxis.get_ticklabels()
-                else 12,
-                "event_font_size": self.event_text_objects[0][0].get_fontsize()
-                if getattr(self, "event_text_objects", None)
-                else 10,
-                "event_font_family": self.event_text_objects[0][0].get_fontname()
-                if getattr(self, "event_text_objects", None)
-                else "Arial",
-                "event_bold": str(self.event_text_objects[0][0].get_fontweight()).lower() == "bold"
-                if getattr(self, "event_text_objects", None)
-                else False,
-                "event_italic": self.event_text_objects[0][0].get_fontstyle() == "italic"
-                if getattr(self, "event_text_objects", None)
-                else False,
-                "line_width": self.ax.lines[0].get_linewidth() if self.ax.lines else 2,
-            }
-            return style
-
-        prev = capture_current_style()
-        dialog.set_style(prev)
-        if dialog.exec_() == QDialog.Accepted:
-            style = dialog.get_style()
-            # Apply line width
-            if self.ax.lines:
-                self.ax.lines[0].set_linewidth(style["line_width"])
-            # Update grid
-            self.ax.grid(self.grid_visible, color="#CCC")
-            self.canvas.draw_idle()
+        """Delegate to the main window's style editor for consistency."""
+        main = self.window()
+        if hasattr(main, "open_plot_style_editor_for"):
+            main.open_plot_style_editor_for(
+                self.ax,
+                self.canvas,
+                event_text_objects=getattr(self, "event_text_objects", None),
+                pinned_points=getattr(self, "pins", None),
+            )
 
     def apply_plot_style(self, style):
         """Apply style dictionary to this panel's plot."""


### PR DESCRIPTION
## Summary
- use the main window's plot style editor inside `dual_view_panel`

## Testing
- `pytest -q`
- `python -m compileall -q src`


------
https://chatgpt.com/codex/tasks/task_e_6848c92836808326880b5da56ca3e4f1