### PR TITLE
Add fallback for event frame numbers

### DIFF
--- a/src/vasoanalyzer/gui.py
+++ b/src/vasoanalyzer/gui.py
@@ -1082,6 +1082,13 @@ class VasoAnalyzerApp(QMainWindow):
         if os.path.exists(event_path):
             try:
                 self.event_labels, self.event_times, self.event_frames = load_events(event_path)
+                # If event_frames column was absent, derive frames from times
+                if self.event_frames is None:
+                    trace_times = self.trace_data["Time (s)"].values
+                    self.event_frames = [
+                        int(np.argmin(np.abs(trace_times - t)))
+                        for t in self.event_times
+                    ]
             except Exception as e:
                 QMessageBox.warning(
                     self,
@@ -1754,9 +1761,11 @@ class VasoAnalyzerApp(QMainWindow):
                     idx_pre = -1
 
                 # Calculate frame number based on event time and recording interval
-                frame_number = self.event_times[i]
                 diam_pre = diam_trace.iloc[idx_pre]
-                frame_number = self.event_frames[i]
+                if self.event_frames:
+                    frame_number = self.event_frames[i]
+                else:
+                    frame_number = self.event_times[i]
 
                 # Vertical Line
                 self.ax.axvline(x=frame_number, color='black', linestyle='--', linewidth=0.8)

--- a/tests/test_update_plot.py
+++ b/tests/test_update_plot.py
@@ -1,0 +1,23 @@
+import os
+import pandas as pd
+import numpy as np
+import matplotlib
+matplotlib.use('Agg')
+from PyQt5.QtWidgets import QApplication
+from vasoanalyzer.gui import VasoAnalyzerApp
+
+def test_update_plot_no_frame(tmp_path):
+    os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
+    trace_path = tmp_path / 'trace.csv'
+    df_trace = pd.DataFrame({'Time (s)': [0, 1, 2, 3], 'Inner Diameter': [10, 11, 12, 13]})
+    df_trace.to_csv(trace_path, index=False)
+    event_path = tmp_path / 'trace_table.csv'
+    df_evt = pd.DataFrame({'label': ['A', 'B'], 'time': [1, 2]})
+    df_evt.to_csv(event_path, index=False)
+
+    app = QApplication.instance() or QApplication([])
+    gui = VasoAnalyzerApp()
+    gui.load_trace_and_events(str(trace_path))
+    gui.update_plot()
+    app.quit()
+


### PR DESCRIPTION
## Summary
- derive frame indices when loading events if frame column missing
- use event time when frame list is absent in update_plot
- add regression test for update_plot without frame column

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6849b031c08c8326834e114b59408e27