### PR TITLE
Fix event text frame association

### DIFF
--- a/src/vasoanalyzer/gui.py
+++ b/src/vasoanalyzer/gui.py
@@ -1787,7 +1787,9 @@ class VasoAnalyzerApp(QMainWindow):
                     color="black",
                     clip_on=True,
                 )
-                self.event_text_objects.append((txt, self.frame_number))
+                # store reference to the text object and its corresponding
+                # frame number for later repositioning
+                self.event_text_objects.append((txt, frame_number))
 
                 # populate your table row
                 self.event_table_data.append(


### PR DESCRIPTION
## Summary
- store the event label text object with its associated frame number

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6849b17fecbc83269f7bba5f36652b4b