### PR TITLE
Improve trace loader

### DIFF
--- a/src/vasoanalyzer/trace_loader.py
+++ b/src/vasoanalyzer/trace_loader.py
@@ -1,5 +1,33 @@
 import pandas as pd
 
+
 def load_trace(file_path):
-	trace = pd.read_csv(file_path)
-	return trace
+    """Load a trace CSV and return a DataFrame with standardized columns.
+
+    The loader searches for columns representing time and inner diameter,
+    renaming them to ``"Time (s)"`` and ``"Inner Diameter"`` respectively.
+    If either column is missing an exception is raised.
+    """
+
+    # Try to auto-detect delimiter from the first line
+    with open(file_path, "r", encoding="utf-8-sig") as f:
+        first_line = f.readline()
+        delimiter = "," if "," in first_line else "\t"
+
+    df = pd.read_csv(file_path, delimiter=delimiter, encoding="utf-8-sig")
+
+    # Locate time and diameter columns
+    time_col = next((c for c in df.columns if "time" in c.lower()), None)
+    diam_col = next((c for c in df.columns if "inner" in c.lower() and "diam" in c.lower()), None)
+
+    if time_col is None or diam_col is None:
+        raise ValueError("Trace file must contain Time and Inner Diameter columns")
+
+    # Rename to standardized column names
+    df = df.rename(columns={time_col: "Time (s)", diam_col: "Inner Diameter"})
+
+    # Ensure numeric types
+    df["Time (s)"] = pd.to_numeric(df["Time (s)"], errors="coerce")
+    df["Inner Diameter"] = pd.to_numeric(df["Inner Diameter"], errors="coerce")
+
+    return df

--- a/tests/test_trace_loader.py
+++ b/tests/test_trace_loader.py
@@ -1,0 +1,15 @@
+import pandas as pd
+from vasoanalyzer.trace_loader import load_trace
+
+
+def test_load_trace_column_detection(tmp_path):
+    csv_path = tmp_path / "trace.csv"
+    df = pd.DataFrame({"Time": [0, 1, 2], "Inner Diameter ": [10, 11, 12]})
+    df.to_csv(csv_path, index=False)
+
+    loaded = load_trace(str(csv_path))
+    assert "Time (s)" in loaded.columns
+    assert "Inner Diameter" in loaded.columns
+    assert loaded["Time (s)"].tolist() == [0, 1, 2]
+    assert loaded["Inner Diameter"].tolist() == [10, 11, 12]
+


### PR DESCRIPTION
## Summary
- detect time and diameter columns when loading trace files
- test column detection for trace loader

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6849cd9170248326aa6dc34602c685b4