### PR TITLE
Add docstrings for data loaders

### DIFF
--- a/src/vasoanalyzer/event_loader.py
+++ b/src/vasoanalyzer/event_loader.py
@@ -1,29 +1,47 @@
+"""Utility to load event annotations from CSV or TXT files."""
+
 import pandas as pd
 
+
 def load_events(file_path):
-	# Try to auto-detect delimiter
-	with open(file_path, 'r') as f:
-		first_line = f.readline()
-		delimiter = ',' if ',' in first_line else '\t'
+    """Return event labels, times and optional frames from a table file.
 
-	df = pd.read_csv(file_path, delimiter=delimiter)
+    Args:
+        file_path (str or Path): Path to the event table.
 
-	# Auto-detect columns
-	label_col = next((col for col in df.columns if 'label' in col.lower()), df.columns[0])
-	time_col  = next((col for col in df.columns if 'time' in col.lower()), df.columns[1])
-	frame_col = next((col for col in df.columns if 'frame' in col.lower()), None)
+    Returns:
+        tuple[list[str], list[float], list[int] | None]:
+            A tuple of event labels, times in seconds and optional frame numbers
+            (``None`` if the file lacks a frame column).
 
-	# Convert time to seconds
-	if df[time_col].dtype == 'object':
-		time_sec = pd.to_timedelta(df[time_col]).dt.total_seconds()
-	else:
-		time_sec = df[time_col]
+    Raises:
+        pandas.errors.ParserError: If the file cannot be parsed.
+        ValueError: If time values cannot be converted to seconds.
+    """
 
-	labels = df[label_col].astype(str).tolist()
-	times = time_sec.tolist()
+    # Try to auto-detect delimiter
+    with open(file_path, "r") as f:
+        first_line = f.readline()
+        delimiter = "," if "," in first_line else "\t"
 
-	frames = None
-	if frame_col:
-		frames = df[frame_col].tolist()
+    df = pd.read_csv(file_path, delimiter=delimiter)
 
-	return labels, times, frames
+    # Auto-detect columns
+    label_col = next((col for col in df.columns if "label" in col.lower()), df.columns[0])
+    time_col = next((col for col in df.columns if "time" in col.lower()), df.columns[1])
+    frame_col = next((col for col in df.columns if "frame" in col.lower()), None)
+
+    # Convert time to seconds
+    if df[time_col].dtype == "object":
+        time_sec = pd.to_timedelta(df[time_col]).dt.total_seconds()
+    else:
+        time_sec = df[time_col]
+
+    labels = df[label_col].astype(str).tolist()
+    times = time_sec.tolist()
+
+    frames = None
+    if frame_col:
+        frames = df[frame_col].tolist()
+
+    return labels, times, frames

--- a/src/vasoanalyzer/tiff_loader.py
+++ b/src/vasoanalyzer/tiff_loader.py
@@ -1,3 +1,5 @@
+"""Loading routines for TIFF stacks used for trace snapshots."""
+
 import logging
 import tifffile
 import numpy as np
@@ -5,7 +7,25 @@ import json
 
 log = logging.getLogger(__name__)
 
+
 def load_tiff(file_path, max_frames=300):
+    """Load a subset of frames from a TIFF file.
+
+    Args:
+        file_path (str or Path): Path to the TIFF stack.
+        max_frames (int, optional): Maximum number of frames to load. Frames are
+            sampled evenly across the stack if it contains more than this value.
+            Defaults to ``300``.
+
+    Returns:
+        tuple[list[numpy.ndarray], list[dict]]: Extracted frames and metadata for
+            each sampled frame.
+
+    Raises:
+        json.JSONDecodeError: If a frame description contains invalid JSON.
+        OSError: If the file cannot be read as a TIFF.
+    """
+
     frames = []
     frames_metadata = []
     

--- a/src/vasoanalyzer/trace_loader.py
+++ b/src/vasoanalyzer/trace_loader.py
@@ -1,12 +1,21 @@
+"""Helper routines for loading diameter trace CSV files."""
+
 import pandas as pd
 
 
 def load_trace(file_path):
-    """Load a trace CSV and return a DataFrame with standardized columns.
+    """Load a trace CSV and return a standardized DataFrame.
 
-    The loader searches for columns representing time and inner diameter,
-    renaming them to ``"Time (s)"`` and ``"Inner Diameter"`` respectively.
-    If either column is missing an exception is raised.
+    Args:
+        file_path (str or Path): Path to the CSV file.
+
+    Returns:
+        pandas.DataFrame: Data with ``"Time (s)"`` and ``"Inner Diameter"``
+        columns converted to numeric types.
+
+    Raises:
+        ValueError: If no time or inner diameter column can be found.
+        pandas.errors.ParserError: If the CSV cannot be parsed.
     """
 
     # Try to auto-detect delimiter from the first line


### PR DESCRIPTION
## Summary
- document CSV trace loader behavior and errors
- describe event table loader inputs and outputs
- explain TIFF loader sampling and metadata extraction

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684a1a182d3083268e2da37dbcd37213