### PR TITLE
Fix invalid RGBA for Matplotlib hover labels

### DIFF
--- a/src/vasoanalyzer/gui.py
+++ b/src/vasoanalyzer/gui.py
@@ -51,7 +51,7 @@ from vasoanalyzer.tiff_loader import load_tiff
 from vasoanalyzer.event_loader import load_events
 from vasoanalyzer.excel_mapper import ExcelMappingDialog, update_excel_file
 from vasoanalyzer.version_checker import check_for_new_version
-from vasoanalyzer.theme_manager import CURRENT_THEME
+from vasoanalyzer.theme_manager import CURRENT_THEME, css_rgba_to_mpl
 
 log = logging.getLogger(__name__)
 
@@ -685,7 +685,7 @@ class VasoAnalyzerApp(QMainWindow):
             textcoords="offset points",
             bbox=dict(
                 boxstyle="round,pad=0.3",
-                fc=CURRENT_THEME['hover_label_bg'],
+                fc=css_rgba_to_mpl(CURRENT_THEME['hover_label_bg']),
                 ec=CURRENT_THEME['hover_label_border'],
                 lw=1,
             ),
@@ -1597,7 +1597,7 @@ class VasoAnalyzerApp(QMainWindow):
                     textcoords="offset points",
                     bbox=dict(
                         boxstyle="round,pad=0.3",
-                        fc=CURRENT_THEME['hover_label_bg'],
+                        fc=css_rgba_to_mpl(CURRENT_THEME['hover_label_bg']),
                         ec=CURRENT_THEME['hover_label_border'],
                         lw=1,
                     ),
@@ -1681,7 +1681,7 @@ class VasoAnalyzerApp(QMainWindow):
             textcoords="offset points",
             bbox=dict(
                 boxstyle="round,pad=0.3",
-                fc=CURRENT_THEME['hover_label_bg'],
+                fc=css_rgba_to_mpl(CURRENT_THEME['hover_label_bg']),
                 ec=CURRENT_THEME['hover_label_border'],
                 lw=1,
             ),
@@ -1897,7 +1897,7 @@ class VasoAnalyzerApp(QMainWindow):
                 textcoords="offset points",
                 bbox=dict(
                     boxstyle="round,pad=0.3",
-                    fc=CURRENT_THEME['hover_label_bg'],
+                    fc=css_rgba_to_mpl(CURRENT_THEME['hover_label_bg']),
                     ec=CURRENT_THEME['hover_label_border'],
                     lw=1,
                 ),
@@ -2380,7 +2380,7 @@ class VasoAnalyzerApp(QMainWindow):
                 textcoords="offset points",
                 bbox=dict(
                     boxstyle="round,pad=0.3",
-                    fc=CURRENT_THEME['hover_label_bg'],
+                    fc=css_rgba_to_mpl(CURRENT_THEME['hover_label_bg']),
                     ec=CURRENT_THEME['hover_label_border'],
                     lw=1,
                 ),

--- a/src/vasoanalyzer/theme_manager.py
+++ b/src/vasoanalyzer/theme_manager.py
@@ -1,6 +1,7 @@
 from PyQt5.QtGui import QPalette, QColor, QFont
 from PyQt5.QtWidgets import QApplication
 from matplotlib import rcParams
+import re
 
 # -----------------------------------------------------------------------------
 # Centralized Theme Definitions for VasoAnalyzer
@@ -50,6 +51,19 @@ FONTS = {
     'category_size': 15,
     'description_size': 17,
 }
+
+# -----------------------------------------------------------------------------
+# Utility
+# -----------------------------------------------------------------------------
+
+def css_rgba_to_mpl(color: str):
+    """Convert an ``rgba(r,g,b,a)`` CSS color string to a matplotlib RGBA tuple."""
+    if isinstance(color, str):
+        m = re.fullmatch(r"rgba\((\d+),\s*(\d+),\s*(\d+),\s*(\d+)\)", color)
+        if m:
+            r, g, b, a = map(int, m.groups())
+            return (r / 255, g / 255, b / 255, a / 255)
+    return color
 
 # -----------------------------------------------------------------------------
 # Qt Palette & Stylesheet Application


### PR DESCRIPTION
## Summary
- handle CSS-style rgba color strings
- convert tooltip background color before passing to Matplotlib

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684a2adec6848326bae1a768d1a9f3d1