### PR TITLE
Remove dark theme support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Designed for researchers. Powered by Python. Zero coding required.
 - **🧾 Excel Mapper Integration**
   - Map table into existing `.xlsx` templates
   - Preserves formulas & formatting
-- **🌗 Toggle Dark Theme** via *View → Toggle Dark Theme*
 - **⚡ UI & Performance**
   - Responsive layout, light theme, compact toolbar
   - Fast TIFF loading, slider sync, smooth tooltips

--- a/src/main.py
+++ b/src/main.py
@@ -16,11 +16,7 @@ from PyQt5.QtGui import QIcon
 from utils.config import APP_VERSION
 
 from vasoanalyzer.gui import VasoAnalyzerApp
-from vasoanalyzer.theme_manager import (
-    apply_dark_theme,
-    apply_light_theme,
-    is_system_dark_mode,
-)
+from vasoanalyzer.theme_manager import apply_light_theme
 import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_qt5 import MainWindow
@@ -70,11 +66,8 @@ class VasoAnalyzerLauncher:
         if icon_path and os.path.exists(icon_path):
             self.app.setWindowIcon(QIcon(icon_path))
 
-        # === Apply theme based on system preference ===
-        if is_system_dark_mode():
-                apply_dark_theme()
-        else:
-                apply_light_theme()
+        # === Apply the application theme ===
+        apply_light_theme()
 
         # === Load and Show Splash Screen from PNG file ===
         splash_path = os.path.join(os.path.dirname(__file__), "vasoanalyzer", "VasoAnalyzerSplashScreen.png")

--- a/src/vasoanalyzer/gui.py
+++ b/src/vasoanalyzer/gui.py
@@ -53,8 +53,6 @@ from vasoanalyzer.excel_mapper import ExcelMappingDialog, update_excel_file
 from vasoanalyzer.version_checker import check_for_new_version
 from vasoanalyzer.theme_manager import (
     CURRENT_THEME,
-    LIGHT_THEME,
-    apply_dark_theme,
     apply_light_theme,
     css_rgba_to_mpl,
 )
@@ -399,10 +397,6 @@ class VasoAnalyzerApp(QMainWindow):
         view_menu.addAction(self.action_dual)
 
         view_menu.addSeparator()
-
-        toggle_theme_act = QAction("Toggle Dark Theme", self)
-        toggle_theme_act.triggered.connect(self.toggle_theme)
-        view_menu.addAction(toggle_theme_act)
 
         # 5) Full‑Screen
         fs_act = QAction("Full‑Screen Mode", self)
@@ -2610,30 +2604,6 @@ class VasoAnalyzerApp(QMainWindow):
             self.ax.grid(False)
         self.canvas.draw_idle()
 
-    def toggle_theme(self):
-        """Switch between light and dark application themes."""
-        if CURRENT_THEME is LIGHT_THEME:
-            apply_dark_theme()
-        else:
-            apply_light_theme()
-
-        # Update figure and axes background colors
-        self.fig.set_facecolor(CURRENT_THEME['window_bg'])
-        self.ax.set_facecolor(CURRENT_THEME['window_bg'])
-
-        # Update hover label colors
-        if hasattr(self, 'hover_annotation') and self.hover_annotation:
-            patch = self.hover_annotation.get_bbox_patch()
-            patch.set_facecolor(css_rgba_to_mpl(CURRENT_THEME['hover_label_bg']))
-            patch.set_edgecolor(CURRENT_THEME['hover_label_border'])
-
-        # Update pinned annotation colors
-        for _, label in self.pinned_points:
-            patch = label.get_bbox_patch()
-            patch.set_facecolor(css_rgba_to_mpl(CURRENT_THEME['hover_label_bg']))
-            patch.set_edgecolor(CURRENT_THEME['hover_label_border'])
-
-        self.canvas.draw_idle()
 
 
 # [L] ========================= AxisSettingsDialog =========================

--- a/src/vasoanalyzer/theme_manager.py
+++ b/src/vasoanalyzer/theme_manager.py
@@ -1,4 +1,4 @@
-from PyQt5.QtGui import QPalette, QColor, QFont
+from PyQt5.QtGui import QPalette, QColor
 from PyQt5.QtWidgets import QApplication
 from matplotlib import rcParams
 import re
@@ -6,7 +6,7 @@ import re
 # -----------------------------------------------------------------------------
 # Centralized Theme Definitions for VasoAnalyzer
 # -----------------------------------------------------------------------------
-# Define color tokens for light and dark themes
+# Define color tokens for the application theme
 LIGHT_THEME = {
     'window_bg': '#F5F5F5',
     'text': '#000000',
@@ -20,21 +20,6 @@ LIGHT_THEME = {
     'hover_label_bg': 'rgba(255,255,255,220)',
     'hover_label_border': '#888888',
     'grid_color': '#CCCCCC',
-}
-
-DARK_THEME = {
-    'window_bg': '#2E2E2E',
-    'text': '#FFFFFF',
-    'button_bg': '#3C3C3C',
-    'button_hover_bg': '#505050',
-    'toolbar_bg': '#333333',
-    'table_bg': '#3C3C3C',
-    'table_text': '#FFFFFF',
-    'selection_bg': '#505470',
-    'alternate_bg': '#2A2A2A',
-    'hover_label_bg': 'rgba(60,60,60,220)',
-    'hover_label_border': '#AAAAAA',
-    'grid_color': '#444444',
 }
 
 # Currently applied theme; defaults to light until explicitly changed
@@ -175,45 +160,3 @@ def apply_light_theme():
     if app is not None:
         app.setStyleSheet(apply_qt_stylesheet(LIGHT_THEME))
     apply_matplotlib_style(LIGHT_THEME)
-
-
-def apply_dark_theme():
-    global CURRENT_THEME
-    CURRENT_THEME = DARK_THEME
-    apply_qt_palette(DARK_THEME)
-    app = QApplication.instance()
-    if app is not None:
-        app.setStyleSheet(apply_qt_stylesheet(DARK_THEME))
-    apply_matplotlib_style(DARK_THEME)
-
-
-def is_system_dark_mode() -> bool:
-    """Return True if the OS preference is set to dark mode."""
-    import sys
-    import subprocess
-
-    if sys.platform == "darwin":
-        try:
-            result = subprocess.run(
-                ["defaults", "read", "-g", "AppleInterfaceStyle"],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-            )
-            return result.returncode == 0 and result.stdout.strip().lower() == "dark"
-        except Exception:
-            return False
-    elif sys.platform.startswith("win"):
-        try:
-            import winreg
-
-            with winreg.OpenKey(
-                winreg.HKEY_CURRENT_USER,
-                r"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize",
-            ) as key:
-                value, _ = winreg.QueryValueEx(key, "AppsUseLightTheme")
-            return value == 0
-        except Exception:
-            return False
-    else:
-        return False


### PR DESCRIPTION
## Summary
- drop dark theme from `theme_manager`
- always apply light theme in the launcher
- clean up UI menu and docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684a30e2e26c83268136155702aa7a07