### PR TITLE
Clamp subplot dialog params

### DIFF
--- a/src/vasoanalyzer/gui.py
+++ b/src/vasoanalyzer/gui.py
@@ -3090,7 +3090,28 @@ class SubplotLayoutDialog(QDialog):
         return {name: ctrl.value() for name, ctrl in self.controls.items()}
 
     def update_preview(self, *_):
-        self.preview_fig.subplots_adjust(**self.get_values())
+        params = self.get_values()
+        # Clamp parameters to [0, 1]
+        epsilon = 1e-3
+        for key in params:
+            params[key] = max(0.0, min(1.0, params[key]))
+
+        # Ensure left < right and bottom < top
+        if params["right"] <= params["left"]:
+            if params["left"] >= 1.0 - epsilon:
+                params["left"] = 1.0 - epsilon
+                params["right"] = 1.0
+            else:
+                params["right"] = min(1.0, params["left"] + epsilon)
+
+        if params["top"] <= params["bottom"]:
+            if params["bottom"] >= 1.0 - epsilon:
+                params["bottom"] = 1.0 - epsilon
+                params["top"] = 1.0
+            else:
+                params["top"] = min(1.0, params["bottom"] + epsilon)
+
+        self.preview_fig.subplots_adjust(**params)
         self.preview_canvas.draw_idle()
 
 

--- a/tests/test_subplot_layout_dialog.py
+++ b/tests/test_subplot_layout_dialog.py
@@ -1,0 +1,21 @@
+import os
+import matplotlib
+matplotlib.use('Agg')
+from PyQt5.QtWidgets import QApplication
+from matplotlib.figure import Figure
+from vasoanalyzer.gui import SubplotLayoutDialog
+
+
+def test_subplot_layout_dialog_extreme_values():
+    os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
+    app = QApplication.instance() or QApplication([])
+    fig = Figure()
+    dialog = SubplotLayoutDialog(None, fig)
+    dialog.controls['left'].setValue(1.0)
+    dialog.controls['right'].setValue(0.0)
+    dialog.controls['bottom'].setValue(1.0)
+    dialog.controls['top'].setValue(0.0)
+    dialog.controls['wspace'].setValue(1.5)
+    dialog.controls['hspace'].setValue(1.5)
+    dialog.update_preview()
+    app.quit()


### PR DESCRIPTION
## Summary
- ensure subplot layout dialog clamps parameters before calling `subplots_adjust`
- add regression test for extreme values

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for matplotlib/pandas)*

------
https://chatgpt.com/codex/tasks/task_e_684a3408689083268acb2e236ba773e6