### PR TITLE
Apply default style automatically

### DIFF
--- a/src/vasoanalyzer/gui.py
+++ b/src/vasoanalyzer/gui.py
@@ -1765,6 +1765,8 @@ class VasoAnalyzerApp(QMainWindow):
             self.populate_table()
             self.auto_export_table()
 
+        # Apply plot style (defaults on first load)
+        self.apply_plot_style(self.get_current_plot_style())
         self.canvas.draw_idle()
 
     def scroll_plot(self):


### PR DESCRIPTION
## Summary
- make the plotted dataset automatically adopt the current style
- keep the default font/style values

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_684ad3b1fae4832694952f724c449eaa