### PR TITLE
Remove redundant menu addition in launcher

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -93,13 +93,6 @@ class VasoAnalyzerLauncher:
         try:
             print("🚀 Attempting to create VasoAnalyzerApp window...")
             self.window = VasoAnalyzerApp()
-            file_menu = self.window.menuBar().actions()[0].menu()
-            save_act = QAction("Save Project", self.window)
-            save_act.triggered.connect(self.window.save_project)
-            open_act = QAction("Open Project", self.window)
-            open_act.triggered.connect(self.window.open_project)
-            file_menu.addAction(save_act)
-            file_menu.addAction(open_act)
             self.window.show()
             print("✅ Main window shown successfully!")
         except Exception as e:


### PR DESCRIPTION
## Summary
- ensure VasoAnalyzerApp builds its own project menu
- remove temporary menu modifications in main launcher

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684b4863d47083268ed082fbbeb64501