### PR TITLE
Use .vasoproj extension for project files

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Designed for researchers. Powered by Python. Zero coding required.
 ---
 ## Projects & Ns
 
-Organize related experiments together in a single `.vaso` file. Each project can contain multiple experiments and each experiment holds your N‑samples.
+Organize related experiments together in a single `.vasoproj` file. Each project can contain multiple experiments and each experiment holds your N‑samples.
 
 ![Sidebar demo](docs/projects_demo.png)
 
@@ -69,6 +69,7 @@ Organize related experiments together in a single `.vaso` file. Each project can
 2. **Project → Add Experiment** and **Project → Add N** build your experiment tree.
 3. Right‑click an N and choose **Load Data Into N…** to import trace and events.
 4. Save progress with **Project → Save Project** and reopen using **Project → Open Project…**.
+5. **Save N As…** exports a single sample to its own `.vaso` file for quick sharing.
 
 ---
 ## 🚀 Download & Install

--- a/src/vasoanalyzer/ui/main_window.py
+++ b/src/vasoanalyzer/ui/main_window.py
@@ -161,7 +161,7 @@ class VasoAnalyzerApp(QMainWindow):
 
     def open_project(self):
         path, _ = QFileDialog.getOpenFileName(
-            self, "Open Project", "", "Vaso Project (*.vaso)"
+            self, "Open Project", "", "Vaso Project (*.vasoproj)"
         )
         if path:
             self.current_project = load_project(path)
@@ -177,11 +177,11 @@ class VasoAnalyzerApp(QMainWindow):
         if not self.current_project:
             return
         path, _ = QFileDialog.getSaveFileName(
-            self, "Save Project As", "", "Vaso Project (*.vaso)"
+            self, "Save Project As", "", "Vaso Project (*.vasoproj)"
         )
         if path:
-            if not path.endswith(".vaso"):
-                path += ".vaso"
+            if not path.endswith(".vasoproj"):
+                path += ".vasoproj"
             save_project(self.current_project, path)
 
     def refresh_project_tree(self):

--- a/tests/test_project_io.py
+++ b/tests/test_project_io.py
@@ -14,7 +14,7 @@ def test_project_save_load(tmp_path):
     exp = Experiment(name="E")
     exp.samples.append(SampleN(name="N1"))
     proj.experiments.append(exp)
-    path = tmp_path / "proj.vaso"
+    path = tmp_path / "proj.vasoproj"
     save_project(proj, path)
     loaded = load_project(path)
     assert loaded.name == "P"
@@ -36,7 +36,7 @@ def test_trace_event_paths_persist(tmp_path):
     s = SampleN(name="N1", trace_path="trace.csv", events_path="events.csv")
     exp.samples.append(s)
     proj.experiments.append(exp)
-    path = tmp_path / "proj.vaso"
+    path = tmp_path / "proj.vasoproj"
     save_project(proj, path)
 
     loaded = load_project(path)


### PR DESCRIPTION
## Summary
- update documentation to reference `.vasoproj` files
- allow UI to open and save projects with `.vasoproj`
- adjust tests for new extension

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'vasoanalyzer')*

------
https://chatgpt.com/codex/tasks/task_e_684b59420554832683ffb1281347255d