### PR TITLE
Embed sample data in projects

### DIFF
--- a/src/vasoanalyzer/project.py
+++ b/src/vasoanalyzer/project.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field, asdict
+from dataclasses import asdict, dataclass, field
 from typing import List, Optional
+
+import pandas as pd
 
 __all__ = [
     "Project",
@@ -22,6 +24,8 @@ class SampleN:
     diameter_data: Optional[List[float]] = None
     exported: bool = False
     column: Optional[str] = None
+    trace_data: Optional[pd.DataFrame] = None
+    events_data: Optional[pd.DataFrame] = None
 
 
 @dataclass
@@ -42,14 +46,53 @@ class Project:
 # JSON I/O --------------------------------------------------------------
 
 
+def sample_to_dict(sample: SampleN) -> dict:
+    data = asdict(sample)
+    if isinstance(sample.trace_data, pd.DataFrame):
+        data["trace_data"] = sample.trace_data.to_dict(orient="list")
+    if isinstance(sample.events_data, pd.DataFrame):
+        data["events_data"] = sample.events_data.to_dict(orient="list")
+    return data
+
+
 def project_to_dict(project: Project) -> dict:
-    return asdict(project)
+    proj_dict = {"name": project.name, "path": project.path, "experiments": []}
+    for exp in project.experiments:
+        exp_dict = {
+            "name": exp.name,
+            "excel_path": exp.excel_path,
+            "next_column": exp.next_column,
+            "samples": [sample_to_dict(s) for s in exp.samples],
+        }
+        proj_dict["experiments"].append(exp_dict)
+    return proj_dict
+
+
+def sample_from_dict(data: dict) -> SampleN:
+    trace_data = data.get("trace_data")
+    if isinstance(trace_data, dict):
+        trace_data = pd.DataFrame(trace_data)
+
+    events_data = data.get("events_data")
+    if isinstance(events_data, dict):
+        events_data = pd.DataFrame(events_data)
+
+    return SampleN(
+        name=data.get("name", ""),
+        trace_path=data.get("trace_path"),
+        events_path=data.get("events_path"),
+        diameter_data=data.get("diameter_data"),
+        exported=data.get("exported", False),
+        column=data.get("column"),
+        trace_data=trace_data,
+        events_data=events_data,
+    )
 
 
 def project_from_dict(data: dict) -> Project:
     experiments = []
     for exp in data.get("experiments", []):
-        samples = [SampleN(**s) for s in exp.get("samples", [])]
+        samples = [sample_from_dict(s) for s in exp.get("samples", [])]
         experiments.append(
             Experiment(
                 name=exp.get("name", ""),

--- a/tests/test_project_io.py
+++ b/tests/test_project_io.py
@@ -1,12 +1,17 @@
 import json
+
+import pandas as pd
+
+from vasoanalyzer.event_loader import load_events
 from vasoanalyzer.project import (
-    Project,
     Experiment,
+    Project,
     SampleN,
-    save_project,
-    load_project,
     export_sample,
+    load_project,
+    save_project,
 )
+from vasoanalyzer.trace_loader import load_trace
 
 
 def test_project_save_load(tmp_path):
@@ -43,3 +48,39 @@ def test_trace_event_paths_persist(tmp_path):
     loaded_s = loaded.experiments[0].samples[0]
     assert loaded_s.trace_path == "trace.csv"
     assert loaded_s.events_path == "events.csv"
+
+
+def test_embedded_data_persistence(tmp_path):
+    trace_path = tmp_path / "trace.csv"
+    df_trace = pd.DataFrame({"Time (s)": [0, 1], "Inner Diameter": [10, 11]})
+    df_trace.to_csv(trace_path, index=False)
+
+    events_path = tmp_path / "events.csv"
+    df_events = pd.DataFrame({"label": ["A"], "time": [0.5], "frame": [5]})
+    df_events.to_csv(events_path, index=False)
+
+    loaded_trace = load_trace(str(trace_path))
+    labels, times, frames = load_events(str(events_path))
+    events_df = pd.DataFrame({"label": labels, "time": times, "frame": frames})
+
+    sample = SampleN(
+        name="N1",
+        trace_path=str(trace_path),
+        events_path=str(events_path),
+        trace_data=loaded_trace,
+        events_data=events_df,
+    )
+    exp = Experiment(name="E", samples=[sample])
+    proj = Project(name="P", experiments=[exp])
+
+    save_path = tmp_path / "proj.vasoproj"
+    save_project(proj, save_path)
+
+    trace_path.unlink()
+    events_path.unlink()
+
+    loaded_proj = load_project(save_path)
+    ls = loaded_proj.experiments[0].samples[0]
+
+    pd.testing.assert_frame_equal(ls.trace_data, loaded_trace)
+    pd.testing.assert_frame_equal(ls.events_data, events_df)


### PR DESCRIPTION
## Summary
- extend `SampleN` with `trace_data` and `events_data`
- serialise/deserialise sample objects with embedded DataFrames
- test persistence of sample data when CSVs are removed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas/matplotlib)*

------
https://chatgpt.com/codex/tasks/task_e_684b6a7d99608326996bb01714eae0e2