### PR TITLE
Expand Save As menu options

### DIFF
--- a/src/vasoanalyzer/ui/main_window.py
+++ b/src/vasoanalyzer/ui/main_window.py
@@ -2857,10 +2857,13 @@ class VasoAnalyzerApp(QMainWindow):
     def show_save_menu(self):
         menu = QMenu(self)
         act_plot = menu.addAction("High‑Res Plot…")
-        act_sample = menu.addAction("Save Data as N…")
+        act_vaso = menu.addAction("Trace && Table (.vaso)…")
+        act_sample = menu.addAction("Save Data to Project…")
         action = menu.exec_(QCursor.pos())
         if action == act_plot:
             self.export_high_res_plot()
+        elif action == act_vaso:
+            self.save_analysis()
         elif action == act_sample:
             self.save_data_as_n()
 


### PR DESCRIPTION
## Summary
- add high-res plot, .vaso export, and project save options to Save As

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684b6d0417b4832684097b75631dbbaf