### PR TITLE
Implement in-project Save As

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Organize related experiments together in a single `.vasoproj` file. Each project
 3. Right‑click an N and choose **Load Data Into N…** to import trace and events.
 4. Save progress with **Project → Save Project** and reopen using **Project → Open Project…**.
 5. **Save N As…** exports a single sample to its own `.vaso` file for quick sharing.
-6. Use the **Save As** toolbar button to export a high‑res plot or save the current data directly as a new N in the selected experiment.
+6. Use the **Save As** toolbar button to export a high‑res plot or choose **Save Data to Project** to embed the current trace and events as a new N in the selected experiment.
 
 ---
 ## 🚀 Download & Install

--- a/src/vasoanalyzer/ui/main_window.py
+++ b/src/vasoanalyzer/ui/main_window.py
@@ -198,7 +198,8 @@ class VasoAnalyzerApp(QMainWindow):
             exp_item.setData(0, Qt.UserRole, exp)
             root.addChild(exp_item)
             for s in exp.samples:
-                status = "✓" if s.trace_path else "✗"
+                has_data = s.trace_path or s.trace_data is not None
+                status = "✓" if has_data else "✗"
                 item = QTreeWidgetItem([f"{s.name} {status}"])
                 item.setData(0, Qt.UserRole, s)
                 exp_item.addChild(item)
@@ -2826,30 +2827,22 @@ class VasoAnalyzerApp(QMainWindow):
         if not ok or not name:
             return
 
-        trace_path, _ = QFileDialog.getSaveFileName(
-            self, "Save Trace CSV", f"{name}_trace.csv", "CSV Files (*.csv)"
-        )
-        if not trace_path:
-            return
-
-        events_path, _ = QFileDialog.getSaveFileName(
-            self, "Save Events CSV", f"{name}_events.csv", "CSV Files (*.csv)"
-        )
-        if not events_path:
-            return
-
+        # Embed the current trace and event data directly into the project
         try:
-            self.trace_data.to_csv(trace_path, index=False)
-            df = pd.DataFrame(
+            events_df = pd.DataFrame(
                 self.event_table_data,
                 columns=["Event", "Time (s)", "ID (µm)", "Frame"],
             )
-            df.to_csv(events_path, index=False)
+            sample = SampleN(
+                name=name,
+                trace_data=self.trace_data.copy(),
+                events_data=events_df,
+            )
         except Exception as e:
             QMessageBox.critical(self, "Save Failed", str(e))
             return
 
-        exp.samples.append(SampleN(name=name, trace_path=trace_path, events_path=events_path))
+        exp.samples.append(sample)
         self.refresh_project_tree()
         if self.current_project.path:
             save_project(self.current_project, self.current_project.path)

--- a/tests/test_save_data_to_project.py
+++ b/tests/test_save_data_to_project.py
@@ -1,0 +1,39 @@
+import os
+import pandas as pd
+import matplotlib
+matplotlib.use('Agg')
+from unittest.mock import patch
+from PyQt5.QtWidgets import QApplication
+from vasoanalyzer.ui.main_window import VasoAnalyzerApp
+from vasoanalyzer.project import Project, Experiment
+
+
+def test_save_data_to_project(tmp_path):
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    trace_path = tmp_path / "trace.csv"
+    df_trace = pd.DataFrame({"Time (s)": [0, 1], "Inner Diameter": [10, 11]})
+    df_trace.to_csv(trace_path, index=False)
+    event_path = tmp_path / "trace_table.csv"
+    df_evt = pd.DataFrame({"label": ["A"], "time": [1.0]})
+    df_evt.to_csv(event_path, index=False)
+
+    app = QApplication.instance() or QApplication([])
+    gui = VasoAnalyzerApp()
+    gui.current_project = Project(name="P")
+    exp = Experiment(name="E")
+    gui.current_project.experiments.append(exp)
+    gui.current_experiment = exp
+
+    gui.load_trace_and_events(str(trace_path))
+
+    with patch("PyQt5.QtWidgets.QInputDialog.getText", return_value=("N1", True)):
+        gui.save_data_as_n()
+
+    assert len(exp.samples) == 1
+    sample = exp.samples[0]
+    pd.testing.assert_frame_equal(sample.trace_data, gui.trace_data)
+    pd.testing.assert_frame_equal(
+        sample.events_data,
+        pd.DataFrame(gui.event_table_data, columns=["Event", "Time (s)", "ID (µm)", "Frame"]),
+    )
+    app.quit()


### PR DESCRIPTION
## Summary
- embed data directly into project when using **Save Data to Project**
- show embedded data in project tree
- document new behaviour in README
- add regression test for embedding data via save-as

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684b6f15b7f88326b893ed4b680164fc