### PR TITLE
Enable metadata display for TIFF snapshots

### DIFF
--- a/src/vasoanalyzer/ui/main_window.py
+++ b/src/vasoanalyzer/ui/main_window.py
@@ -1387,7 +1387,8 @@ class VasoAnalyzerApp(QMainWindow):
             return
 
         try:
-            frames, frames_metadata = load_tiff_preview(file_path)
+            # Use full loader so metadata for each frame is available
+            frames, frames_metadata = load_tiff(file_path)
             valid_frames = []
             valid_metadata = []
 


### PR DESCRIPTION
## Summary
- load TIFF snapshots with metadata information

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684c285bafa883269a9b505fc4ad8091