### PR TITLE
Improve recording interval detection

### DIFF
--- a/src/vasoanalyzer/ui/main_window.py
+++ b/src/vasoanalyzer/ui/main_window.py
@@ -104,7 +104,8 @@ class VasoAnalyzerApp(QMainWindow):
         self.selected_event_marker = None
         self.pinned_points = []
         self.slider_marker = None
-        self.recording_interval = 1  # 0.14    # 140 ms per frame
+        # Default time between frames when metadata is unavailable
+        self.recording_interval = 0.14  # 140 ms per frame
         self.last_replaced_event = None
         self.excel_auto_path = None  # Path to Excel file for auto-update
         self.excel_auto_column = None  # Column letter to use for auto-update
@@ -1408,6 +1409,27 @@ class VasoAnalyzerApp(QMainWindow):
 
             self.snapshot_frames = valid_frames
             self.frames_metadata = valid_metadata
+
+            # Determine recording interval from metadata, otherwise use default
+            if self.frames_metadata:
+                first_meta = self.frames_metadata[0] or {}
+                found = False
+                for key in ("Rec_intvl", "FrameInterval", "FrameTime"):
+                    if key in first_meta:
+                        try:
+                            val = float(str(first_meta[key]).replace("ms", "").strip())
+                            if val > 1:
+                                val /= 1000.0
+                            if val > 0:
+                                self.recording_interval = val
+                                found = True
+                        except (ValueError, TypeError):
+                            pass
+                        break
+                if not found:
+                    self.recording_interval = 0.14
+            else:
+                self.recording_interval = 0.14
 
             # 4) Build a time‑array for each frame
             self.frame_times = []

--- a/tests/test_recording_interval.py
+++ b/tests/test_recording_interval.py
@@ -1,0 +1,44 @@
+import os
+import json
+import numpy as np
+import tifffile
+import matplotlib
+matplotlib.use('Agg')
+from PyQt5.QtWidgets import QApplication
+from unittest.mock import patch
+from vasoanalyzer.ui.main_window import VasoAnalyzerApp
+
+
+def _create_tiff(path, metadata=None):
+    data = np.zeros((2, 5, 5), dtype=np.uint8)
+    if metadata is not None:
+        tifffile.imwrite(path, data[0], description=json.dumps(metadata))
+        tifffile.imwrite(path, data[1], append=True)
+    else:
+        tifffile.imwrite(path, data)
+
+
+def test_recording_interval_from_metadata(tmp_path):
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    tiff_path = tmp_path / "stack.tiff"
+    _create_tiff(tiff_path, {"Rec_intvl": 200})
+
+    app = QApplication.instance() or QApplication([])
+    gui = VasoAnalyzerApp()
+    with patch("PyQt5.QtWidgets.QFileDialog.getOpenFileName", return_value=(str(tiff_path), "")):
+        gui.load_snapshot()
+    assert abs(gui.recording_interval - 0.2) < 1e-6
+    app.quit()
+
+
+def test_recording_interval_default(tmp_path):
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    tiff_path = tmp_path / "stack.tiff"
+    _create_tiff(tiff_path)
+
+    app = QApplication.instance() or QApplication([])
+    gui = VasoAnalyzerApp()
+    with patch("PyQt5.QtWidgets.QFileDialog.getOpenFileName", return_value=(str(tiff_path), "")):
+        gui.load_snapshot()
+    assert abs(gui.recording_interval - 0.14) < 1e-6
+    app.quit()


### PR DESCRIPTION
## Summary
- set default recording interval to 0.14 s
- infer recording interval from TIFF metadata when loading snapshots
- add regression tests for recording interval handling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684c2a32076c8326873d9c00c066358d