### PR TITLE
Fix unreadable tooltips

### DIFF
--- a/src/vasoanalyzer/theme_manager.py
+++ b/src/vasoanalyzer/theme_manager.py
@@ -110,6 +110,13 @@ QToolButton {{
 QToolButton:hover {{
     background-color: {theme['button_hover_bg']};
 }}
+QToolTip {{
+    background-color: {theme['hover_label_bg']};
+    color: {theme['text']};
+    border: 1px solid {theme['hover_label_border']};
+    padding: 2px 6px;
+    border-radius: 5px;
+}}
 QTableWidget {{
     background-color: {theme['table_bg']};
     color: {theme['table_text']};


### PR DESCRIPTION
## Summary
- ensure tooltips use light theme colors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684ca621eddc83269e033da4079458e6