### PR TITLE
Enhance startup and welcome flow

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -112,6 +112,7 @@ class VasoAnalyzerLauncher:
             print("🚀 Attempting to create VasoAnalyzerApp window...")
             self.window = VasoAnalyzerApp()
             self.window.show()
+            QTimer.singleShot(100, self.window.show_welcome_dialog)
             print("✅ Main window shown successfully!")
         except Exception as e:
             print(f"❗ Error launching main window: {e}")

--- a/src/vasoanalyzer/ui/dialogs/welcome_dialog.py
+++ b/src/vasoanalyzer/ui/dialogs/welcome_dialog.py
@@ -22,6 +22,7 @@ class WelcomeDialog(QDialog):
     GETTING_STARTED = 1
     CREATE_PROJECT = 2
     OPEN_PROJECT = 3
+    QUICK_ANALYSIS = 4
 
     def __init__(self, recent_projects: list[str] | None = None, parent=None) -> None:
         super().__init__(parent)
@@ -42,11 +43,13 @@ class WelcomeDialog(QDialog):
         l0 = QVBoxLayout(page0)
         l0.addWidget(QLabel("<b>Welcome! Choose an option:</b>"))
         btn_start = QPushButton("Getting Started")
+        btn_quick = QPushButton("Quick Analysis")
         btn_create = QPushButton("Create New Project")
         btn_open = QPushButton("Open Project")
-        for btn in (btn_start, btn_create, btn_open):
+        for btn in (btn_start, btn_quick, btn_create, btn_open):
             btn.setMinimumHeight(40)
         l0.addWidget(btn_start)
+        l0.addWidget(btn_quick)
         l0.addWidget(btn_create)
         l0.addWidget(btn_open)
         self.dont_show_chk = QCheckBox("Don't show this again")
@@ -90,6 +93,7 @@ class WelcomeDialog(QDialog):
 
         # Connections ------------------------------------------------------
         btn_start.clicked.connect(lambda: self.done(self.GETTING_STARTED))
+        btn_quick.clicked.connect(lambda: self.done(self.QUICK_ANALYSIS))
         btn_create.clicked.connect(lambda: self.stack.setCurrentIndex(1))
         btn_open.clicked.connect(lambda: self.stack.setCurrentIndex(2))
 

--- a/src/vasoanalyzer/ui/main_window.py
+++ b/src/vasoanalyzer/ui/main_window.py
@@ -139,7 +139,6 @@ class VasoAnalyzerApp(QMainWindow):
         self.canvas.setMouseTracking(True)
 
         self.check_for_updates_at_startup()
-        self.show_welcome_dialog()
 
     def setup_project_sidebar(self):
         from .project_explorer import ProjectExplorerWidget
@@ -997,33 +996,43 @@ class VasoAnalyzerApp(QMainWindow):
         from .dialogs.welcome_dialog import WelcomeDialog
 
         dlg = WelcomeDialog(self.recent_projects, self)
-        result = dlg.exec_()
-        if dlg.dont_show:
-            settings.setValue("welcomeShown", True)
+        while True:
+            result = dlg.exec_()
+            if dlg.dont_show:
+                settings.setValue("welcomeShown", True)
 
-        if result == WelcomeDialog.GETTING_STARTED:
-            self.show_tutorial()
-        elif result == WelcomeDialog.CREATE_PROJECT:
-            if dlg.project_name:
-                self.current_project = Project(name=dlg.project_name)
-                self.refresh_project_tree()
-                self.project_dock.show()
-                if dlg.experiment_name:
-                    exp = Experiment(name=dlg.experiment_name)
-                    self.current_project.experiments.append(exp)
+            if result == WelcomeDialog.GETTING_STARTED:
+                self.show_tutorial()
+                dlg.stack.setCurrentIndex(0)
+                continue
+            elif result == getattr(WelcomeDialog, "QUICK_ANALYSIS", -1):
+                self.load_trace_and_events()
+                break
+            elif result == WelcomeDialog.CREATE_PROJECT:
+                if dlg.project_name:
+                    self.current_project = Project(name=dlg.project_name)
                     self.refresh_project_tree()
-        elif result == WelcomeDialog.OPEN_PROJECT:
-            path = dlg.selected_project
-            if not path:
-                path, _ = QFileDialog.getOpenFileName(
-                    self, "Open Project", "", "Vaso Files (*.vaso)"
-                )
-            if path:
-                self.current_project = open_project(path)
-                self.apply_ui_state(getattr(self.current_project, "ui_state", None))
-                self.refresh_project_tree()
-                self.project_dock.show()
-                self.update_recent_projects(path)
+                    self.project_dock.show()
+                    if dlg.experiment_name:
+                        exp = Experiment(name=dlg.experiment_name)
+                        self.current_project.experiments.append(exp)
+                        self.refresh_project_tree()
+                break
+            elif result == WelcomeDialog.OPEN_PROJECT:
+                path = dlg.selected_project
+                if not path:
+                    path, _ = QFileDialog.getOpenFileName(
+                        self, "Open Project", "", "Vaso Files (*.vaso)"
+                    )
+                if path:
+                    self.current_project = open_project(path)
+                    self.apply_ui_state(getattr(self.current_project, "ui_state", None))
+                    self.refresh_project_tree()
+                    self.project_dock.show()
+                    self.update_recent_projects(path)
+                break
+            else:
+                break
 
     # [C] ========================= UI SETUP (initUI) ======================================
     def initUI(self):


### PR DESCRIPTION
## Summary
- show Welcome dialog after the splash screen
- rework Welcome dialog with new Quick Analysis option
- allow returning to main page after Getting Started tutorial

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684cbce012148326a3d9b18036b741f7