### PR TITLE
Fix toolbar icon loading in PyInstaller build

### DIFF
--- a/src/VasoAnalyzer.spec
+++ b/src/VasoAnalyzer.spec
@@ -15,8 +15,9 @@ else:
 spec_dir = os.path.dirname(__file__)
 project_dir = os.getcwd()
 req_subs = collect_submodules('requests')
-xl_subs  = collect_submodules('openpyxl')
-icon_dir = os.path.join(spec_dir, 'icons')
+xl_subs = collect_submodules('openpyxl')
+# Collect toolbar icon SVGs from the project root.
+icon_dir = os.path.join(project_dir, 'icons')
 icon_datas = [(os.path.join(icon_dir, f), 'icons') for f in os.listdir(icon_dir)]
 
 a = Analysis(

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,18 @@
+"""Utility helpers for the VasoAnalyzer package."""
+
+import os
+import sys
+
+
+def resource_path(*parts: str) -> str:
+    """Return absolute path to a bundled resource.
+
+    When running from a PyInstaller bundle, data files are extracted to a
+    temporary directory available via ``sys._MEIPASS``. During normal
+    development, resources live in the project root. This helper constructs a
+    path that works in both cases.
+    """
+
+    base = getattr(sys, "_MEIPASS", os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+    return os.path.join(base, *parts)
+

--- a/src/vasoanalyzer/ui/main_window.py
+++ b/src/vasoanalyzer/ui/main_window.py
@@ -460,9 +460,9 @@ class VasoAnalyzerApp(QMainWindow):
 
     def icon_path(self, filename):
         """Return absolute path to an icon shipped with the application."""
-        return os.path.join(
-            os.path.dirname(__file__), "..", "..", "..", "icons", filename
-        )
+        from utils import resource_path
+
+        return resource_path("icons", filename)
 
     def sync_slider_with_plot(self, event=None):
         if self.trace_data is None:


### PR DESCRIPTION
## Summary
- provide `resource_path` helper for locating bundled files
- update `icon_path` to use `resource_path`
- gather icons from project root in PyInstaller spec

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684d88c2772083268d39ddaa9ee3d128