### PR TITLE
Fix BUNDLE step for macOS

### DIFF
--- a/src/VasoAnalyzer.spec
+++ b/src/VasoAnalyzer.spec
@@ -78,7 +78,7 @@ coll = COLLECT(
 
 if sys.platform == 'darwin':
     app = BUNDLE(
-        exe,
+        coll,
         name='VasoAnalyzer 1.7.app',
         icon='vasoanalyzer/VasoAnalyzerIcon.icns',
         bundle_identifier=None,


### PR DESCRIPTION
## Summary
- ensure PyInstaller macOS bundle uses the collected files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pyinstaller src/VasoAnalyzer.spec` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db2f45db48326a5a41dc8a948cc31