### PR TITLE
Auto-save project state on app exit

### DIFF
--- a/src/vasoanalyzer/ui/main_window.py
+++ b/src/vasoanalyzer/ui/main_window.py
@@ -3241,3 +3241,12 @@ class VasoAnalyzerApp(QMainWindow):
         if "axis_ylim" in state:
             self.ax.set_ylim(state["axis_ylim"])
         self.canvas.draw_idle()
+
+    def closeEvent(self, event):
+        if self.current_project and self.current_project.path:
+            try:
+                self.current_project.ui_state = self.gather_ui_state()
+                save_project_file(self.current_project)
+            except Exception as e:
+                log.error("Failed to auto-save project:\n%s", e)
+        super().closeEvent(event)

--- a/tests/test_auto_save_on_close.py
+++ b/tests/test_auto_save_on_close.py
@@ -1,0 +1,31 @@
+import os
+import pandas as pd
+import matplotlib
+matplotlib.use('Agg')
+from PyQt5.QtWidgets import QApplication
+from vasoanalyzer.ui.main_window import VasoAnalyzerApp
+from vasoanalyzer.project import Project, Experiment, save_project, load_project
+
+
+def test_auto_save_on_close(tmp_path):
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    path = tmp_path / "proj.vaso"
+    proj = Project(name="P")
+    exp = Experiment(name="E")
+    proj.experiments.append(exp)
+    save_project(proj, path)
+
+    app = QApplication.instance() or QApplication([])
+    gui = VasoAnalyzerApp()
+    gui.current_project = load_project(path)
+
+    # Modify UI state
+    gui.ax.set_xlim(1, 2)
+    gui.ax.set_ylim(3, 4)
+
+    gui.close()
+
+    reloaded = load_project(path)
+    assert reloaded.ui_state["axis_xlim"] == [1.0, 2.0]
+    assert reloaded.ui_state["axis_ylim"] == [3.0, 4.0]
+    app.quit()


### PR DESCRIPTION
## Summary
- auto-save the project when closing the GUI
- test that UI state is persisted after closing the app

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684db59c96dc832684fa246a865de1c7