### PR TITLE
Add legacy VasoTracker support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Designed for researchers. Powered by Python. Zero coding required.
 
 ## 🧰 Key Features in v1.7
 
-- **📊 Load & visualize trace data** from `.csv`  
+- **📊 Load & visualize trace data** from `.csv`
+- **⬅️ Legacy file support** automatically detects old VasoTracker columns and event filenames
 - **📍 Import & display event tables** (CSV/TXT)  
 - **🖼️ Synchronized TIFF snapshots** with red trace‑time markers  
 - **🧠 Interactive plotting**: zoom, pan, hover‑to‑read, and pin points  

--- a/src/vasoanalyzer/dual_view_panel.py
+++ b/src/vasoanalyzer/dual_view_panel.py
@@ -12,7 +12,7 @@ import numpy as np
 import os
 
 from vasoanalyzer.trace_loader import load_trace
-from vasoanalyzer.event_loader import load_events
+from vasoanalyzer.event_loader import load_events, find_matching_event_file
 
 
 class DataViewPanel(QWidget):
@@ -199,14 +199,13 @@ class DataViewPanel(QWidget):
         if not file_path:
             return
         df = load_trace(file_path)
-        base = os.path.splitext(os.path.basename(file_path))[0]
-        evp = os.path.join(os.path.dirname(file_path), f"{base}_table.csv")
+        evp = find_matching_event_file(file_path)
         events = []
-        if os.path.exists(evp):
+        if evp and os.path.exists(evp):
             try:
                 lbls, tms, _ = load_events(evp)
                 events = list(zip(lbls, tms))
-            except:
+            except Exception:
                 pass
         # delegate to panel loader
         self.load_trace_and_events(df, events)

--- a/src/vasoanalyzer/event_loader.py
+++ b/src/vasoanalyzer/event_loader.py
@@ -1,5 +1,6 @@
 """Utility to load event annotations from CSV or TXT files."""
 
+import os
 import pandas as pd
 
 
@@ -45,3 +46,29 @@ def load_events(file_path):
         frames = df[frame_col].tolist()
 
     return labels, times, frames
+
+
+def find_matching_event_file(trace_file: str) -> str | None:
+    """Return the path to a matching event file if it exists."""
+    base = os.path.splitext(os.path.basename(trace_file))[0]
+    folder = os.path.dirname(trace_file)
+
+    patterns = [
+        f"{base}_table.csv",
+        f"{base}_Table.csv",
+        f"{base} table.csv",
+        f"{base} Table.csv",
+        f"{base}_table.txt",
+        f"{base}_Table.txt",
+        f"{base} table.txt",
+        f"{base} Table.txt",
+    ]
+
+    for p in patterns:
+        candidate = os.path.join(folder, p)
+        if os.path.exists(candidate):
+            return candidate
+    return None
+
+
+__all__ = ["load_events", "find_matching_event_file"]

--- a/src/vasoanalyzer/trace_loader.py
+++ b/src/vasoanalyzer/trace_loader.py
@@ -1,5 +1,7 @@
 """Helper routines for loading diameter trace CSV files."""
 
+import re
+
 import pandas as pd
 
 
@@ -25,9 +27,24 @@ def load_trace(file_path):
 
     df = pd.read_csv(file_path, delimiter=delimiter, encoding="utf-8-sig")
 
-    # Locate time and diameter columns
-    time_col = next((c for c in df.columns if "time" in c.lower()), None)
-    diam_col = next((c for c in df.columns if "inner" in c.lower() and "diam" in c.lower()), None)
+    def _normalize(col):
+        return re.sub(r"[^a-z0-9]", "", col.lower())
+
+    # Locate time and diameter columns using flexible matching for legacy files
+    time_col = None
+    diam_col = None
+    for c in df.columns:
+        norm = _normalize(c)
+        if time_col is None and ("time" in norm or "sec" in norm or norm == "t"):
+            time_col = c
+        if diam_col is None and (
+            ("inner" in norm and "diam" in norm)
+            or "diam" in norm
+            or norm in {"id", "diameter"}
+        ):
+            diam_col = c
+        if time_col and diam_col:
+            break
 
     if time_col is None or diam_col is None:
         raise ValueError("Trace file must contain Time and Inner Diameter columns")

--- a/src/vasoanalyzer/ui/main_window.py
+++ b/src/vasoanalyzer/ui/main_window.py
@@ -51,7 +51,7 @@ from PyQt5.QtCore import Qt, QTimer, QSize, QSettings, QEvent, QPoint
 from vasoanalyzer.dual_view_panel import DataViewPanel, DualViewWidget
 from vasoanalyzer.trace_loader import load_trace
 from vasoanalyzer.tiff_loader import load_tiff, load_tiff_preview
-from vasoanalyzer.event_loader import load_events
+from vasoanalyzer.event_loader import load_events, find_matching_event_file
 from vasoanalyzer.excel_mapper import ExcelMappingDialog, update_excel_file
 from vasoanalyzer.version_checker import check_for_new_version
 from vasoanalyzer.theme_manager import (
@@ -1417,9 +1417,8 @@ class VasoAnalyzerApp(QMainWindow):
             self.update_recent_files_menu()
 
         # 4) Load the matching events CSV (if it exists)
-        base = os.path.splitext(os.path.basename(file_path))[0]
-        event_path = os.path.join(self.trace_file_path, f"{base}_table.csv")
-        if os.path.exists(event_path):
+        event_path = find_matching_event_file(file_path)
+        if event_path and os.path.exists(event_path):
             try:
                 self.event_labels, self.event_times, self.event_frames = load_events(
                     event_path
@@ -1443,7 +1442,7 @@ class VasoAnalyzerApp(QMainWindow):
             QMessageBox.information(
                 self,
                 "Event File Not Found",
-                f"No matching event file:\n{base}_table.csv",
+                "No matching event file found",
             )
             self.event_labels = []
             self.event_times = []
@@ -2122,14 +2121,13 @@ class VasoAnalyzerApp(QMainWindow):
         df = load_trace(file_path)
 
         # Attempt to find matching events file
-        base = os.path.splitext(os.path.basename(file_path))[0]
-        ev_path = os.path.join(os.path.dirname(file_path), f"{base}_table.csv")
+        ev_path = find_matching_event_file(file_path)
         events = []
-        if os.path.exists(ev_path):
+        if ev_path and os.path.exists(ev_path):
             try:
                 labels, times, _ = load_events(ev_path)
                 events = list(zip(labels, times))
-            except:
+            except Exception:
                 pass
 
         # Feed into the chosen panel

--- a/tests/test_event_file_detection.py
+++ b/tests/test_event_file_detection.py
@@ -1,0 +1,33 @@
+import pandas as pd
+
+from vasoanalyzer.event_loader import find_matching_event_file
+from vasoanalyzer.trace_loader import load_trace
+
+
+def test_find_matching_event_file_modern(tmp_path):
+    trace = tmp_path / "sample.csv"
+    trace.touch()
+    events = tmp_path / "sample_table.csv"
+    events.touch()
+    assert find_matching_event_file(str(trace)) == str(events)
+
+
+def test_find_matching_event_file_legacy(tmp_path):
+    trace = tmp_path / "20191008 MBFA.csv"
+    trace.touch()
+    events = tmp_path / "20191008 MBFA Table.csv"
+    events.touch()
+    assert find_matching_event_file(str(trace)) == str(events)
+
+
+def test_load_trace_legacy_columns(tmp_path):
+    csv_path = tmp_path / "trace.csv"
+    df = pd.DataFrame({"T": [0, 1], "I.D.": [10, 11]})
+    df.to_csv(csv_path, index=False)
+
+    loaded = load_trace(str(csv_path))
+    assert "Time (s)" in loaded.columns
+    assert "Inner Diameter" in loaded.columns
+    assert loaded["Time (s)"].tolist() == [0, 1]
+    assert loaded["Inner Diameter"].tolist() == [10, 11]
+


### PR DESCRIPTION
## Summary
- enhance `load_trace` with more flexible column matching
- detect event files using various legacy naming schemes
- integrate new event-file search in GUI loaders
- document new compatibility in README
- add tests for event filename detection and legacy columns

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684eb82e3b4c8326b2b3bfe94e9c7c81