### PR TITLE
Fix trace loading when duplicate columns present

### DIFF
--- a/src/vasoanalyzer/trace_loader.py
+++ b/src/vasoanalyzer/trace_loader.py
@@ -37,6 +37,9 @@ def load_trace(file_path):
 
     df = pd.read_csv(file_path, delimiter=delimiter, encoding="utf-8-sig")
 
+    # Drop any entirely empty columns that may appear due to malformed files
+    df = df.dropna(axis=1, how="all")
+
     def _normalize(col):
         return re.sub(r"[^a-z0-9]", "", col.lower())
 
@@ -56,11 +59,12 @@ def load_trace(file_path):
         if time_col and diam_col:
             break
 
-    if time_col is None or diam_col is None:
+    if time_col is None or diam_col is None or time_col == diam_col:
         raise ValueError("Trace file must contain Time and Inner Diameter columns")
 
     # Rename to standardized column names
     df = df.rename(columns={time_col: "Time (s)", diam_col: "Inner Diameter"})
+    df = df.loc[:, ~df.columns.duplicated()]
 
     # Ensure numeric types
     df["Time (s)"] = pd.to_numeric(df["Time (s)"], errors="coerce")

--- a/tests/test_trace_loader.py
+++ b/tests/test_trace_loader.py
@@ -13,3 +13,18 @@ def test_load_trace_column_detection(tmp_path):
     assert loaded["Time (s)"].tolist() == [0, 1, 2]
     assert loaded["Inner Diameter"].tolist() == [10, 11, 12]
 
+
+def test_load_trace_duplicate_columns(tmp_path):
+    csv_path = tmp_path / "dup.csv"
+    df = pd.DataFrame({
+        "Time": [0, 1],
+        "Inner Diameter": [5, 6],
+        "Time (s)": [0, 1],
+    })
+    df.to_csv(csv_path, index=False)
+
+    loaded = load_trace(str(csv_path))
+    assert loaded.shape[1] == 2
+    assert loaded["Time (s)"].tolist() == [0, 1]
+    assert loaded["Inner Diameter"].tolist() == [5, 6]
+


### PR DESCRIPTION
## Summary
- handle malformed trace CSVs with duplicate columns
- test duplicate column handling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684ec01d80448326b21dc9843d6bc85a