### PR TITLE
Make event table resizable

### DIFF
--- a/src/vasoanalyzer/dual_view_panel.py
+++ b/src/vasoanalyzer/dual_view_panel.py
@@ -1,8 +1,8 @@
 from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QSlider, QTableWidget,
-    QTableWidgetItem, QAbstractItemView, QPushButton, QFileDialog, QToolButton, QMessageBox
+    QTableWidgetItem, QAbstractItemView, QPushButton, QFileDialog, QToolButton,
+    QMessageBox, QSplitter, QLabel, QHeaderView
 )
-from PyQt5.QtWidgets import QLabel
 from PyQt5.QtGui import QIcon
 from PyQt5.QtCore import Qt, QSize
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas, NavigationToolbar2QT as NavigationToolbar
@@ -112,6 +112,9 @@ class DataViewPanel(QWidget):
         self.event_table.setHorizontalHeaderLabels(["Event", "Time (s)", "ID (µm)"])
         self.event_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.event_table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        header = self.event_table.horizontalHeader()
+        for i in range(3):
+            header.setSectionResizeMode(i, QHeaderView.Interactive)
 
         # --- Layout ---
         main_layout = QVBoxLayout(self)
@@ -127,11 +130,20 @@ class DataViewPanel(QWidget):
         plot_layout = QVBoxLayout()
         plot_layout.addWidget(self.canvas)
         plot_layout.addWidget(self.scroll_slider)
-        # Combine with table
-        row = QHBoxLayout()
-        row.addLayout(plot_layout, 4)
-        row.addWidget(self.event_table, 1)
-        main_layout.addLayout(row)
+
+        left_widget = QWidget()
+        left_widget.setLayout(plot_layout)
+        right_widget = QWidget()
+        right_widget.setLayout(QVBoxLayout())
+        right_widget.layout().addWidget(self.event_table)
+
+        splitter = QSplitter(Qt.Horizontal)
+        splitter.addWidget(left_widget)
+        splitter.addWidget(right_widget)
+        splitter.setStretchFactor(0, 4)
+        splitter.setStretchFactor(1, 1)
+
+        main_layout.addWidget(splitter)
 
         # — Hover Label (exact same logic as main view) —
         self.hover_label = QLabel("", self)

--- a/src/vasoanalyzer/ui/main_window.py
+++ b/src/vasoanalyzer/ui/main_window.py
@@ -1246,9 +1246,8 @@ class VasoAnalyzerApp(QMainWindow):
 
         header = self.event_table.horizontalHeader()
         header.setStretchLastSection(False)
-        header.setSectionResizeMode(0, QHeaderView.ResizeToContents)
-        for i in range(1, 4):
-            header.setSectionResizeMode(i, QHeaderView.Stretch)
+        for i in range(4):
+            header.setSectionResizeMode(i, QHeaderView.Interactive)
         self.event_table.cellClicked.connect(self.table_row_clicked)
         self.event_table.itemChanged.connect(self.handle_table_edit)
         self.event_table.setContextMenuPolicy(Qt.CustomContextMenu)
@@ -1269,14 +1268,20 @@ class VasoAnalyzerApp(QMainWindow):
         right_layout.addWidget(self.event_table)
 
         # ===== Top-Level Layout (Left + Right) =====
-        top_layout = QHBoxLayout()
-        top_layout.setContentsMargins(0, 0, 10, 0)
-        top_layout.setSpacing(0)
-        top_layout.addLayout(left_layout, 4)
-        top_layout.addLayout(right_layout, 1)
+        left_widget = QWidget()
+        left_widget.setLayout(left_layout)
+        right_widget = QWidget()
+        right_widget.setLayout(right_layout)
 
+        splitter = QSplitter(Qt.Horizontal)
+        splitter.addWidget(left_widget)
+        splitter.addWidget(right_widget)
+        splitter.setStretchFactor(0, 4)
+        splitter.setStretchFactor(1, 1)
+
+        self.splitter = splitter
         self.default_main_layout = self.rebuild_default_main_layout()
-        self.main_layout.addLayout(self.default_main_layout)
+        self.main_layout.addWidget(splitter)
 
         # ===== Canvas Interactions =====
         self.canvas.mpl_connect("draw_event", self.update_event_label_positions)
@@ -1511,8 +1516,16 @@ class VasoAnalyzerApp(QMainWindow):
         self.style_event_table()
 
     def style_event_table(self):
-        """Placeholder styling function (no-op)."""
-        return
+        """Ensure all columns start with equal width and remain resizable."""
+        header = self.event_table.horizontalHeader()
+        col_count = self.event_table.columnCount()
+        total_width = self.event_table.viewport().width()
+        if total_width <= 0:
+            total_width = self.event_table.minimumWidth()
+        width = max(1, total_width // col_count)
+        for i in range(col_count):
+            self.event_table.setColumnWidth(i, width)
+            header.setSectionResizeMode(i, QHeaderView.Interactive)
 
     def load_snapshot(self):
         # 1) Prompt for TIFF
@@ -3047,14 +3060,18 @@ class VasoAnalyzerApp(QMainWindow):
         right_layout.addLayout(snapshot_layout)
         right_layout.addWidget(self.event_table)
 
-        # Combine left + right into top layout
-        top_layout = QHBoxLayout()
-        top_layout.setContentsMargins(0, 0, 10, 0)
-        top_layout.setSpacing(0)
-        top_layout.addLayout(left_layout, 4)
-        top_layout.addLayout(right_layout, 1)
+        # Combine left + right into splitter for user-resizable panels
+        left_widget = QWidget()
+        left_widget.setLayout(left_layout)
+        right_widget = QWidget()
+        right_widget.setLayout(right_layout)
 
-        return top_layout
+        splitter = QSplitter(Qt.Horizontal)
+        splitter.addWidget(left_widget)
+        splitter.addWidget(right_widget)
+        splitter.setStretchFactor(0, 4)
+        splitter.setStretchFactor(1, 1)
+        return splitter
 
     # [K] ========================= EXPORT LOGIC (CSV, FIG) ==============================
     def auto_export_table(self):


### PR DESCRIPTION
## Summary
- allow column resize in main event table and dual view table
- set initial column widths and interactive resizing
- use `QSplitter` so the plot and table widths can be adjusted with a slider

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684ecc9dfb488326ad2ed550ba9fb20f