### PR TITLE
Remove splitters from main UI

### DIFF
--- a/src/vasoanalyzer/dual_view_panel.py
+++ b/src/vasoanalyzer/dual_view_panel.py
@@ -1,7 +1,7 @@
 from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QSlider, QTableWidget,
     QTableWidgetItem, QAbstractItemView, QPushButton, QFileDialog, QToolButton,
-    QMessageBox, QSplitter, QLabel, QHeaderView
+    QMessageBox, QLabel, QHeaderView
 )
 from PyQt5.QtGui import QIcon
 from PyQt5.QtCore import Qt, QSize
@@ -137,13 +137,13 @@ class DataViewPanel(QWidget):
         right_widget.setLayout(QVBoxLayout())
         right_widget.layout().addWidget(self.event_table)
 
-        splitter = QSplitter(Qt.Horizontal)
-        splitter.addWidget(left_widget)
-        splitter.addWidget(right_widget)
-        splitter.setStretchFactor(0, 4)
-        splitter.setStretchFactor(1, 1)
+        content_layout = QHBoxLayout()
+        content_layout.setContentsMargins(0, 0, 0, 0)
+        content_layout.setSpacing(0)
+        content_layout.addWidget(left_widget, stretch=4)
+        content_layout.addWidget(right_widget, stretch=1)
 
-        main_layout.addWidget(splitter)
+        main_layout.addLayout(content_layout)
 
         # — Hover Label (exact same logic as main view) —
         self.hover_label = QLabel("", self)

--- a/src/vasoanalyzer/ui/dialogs/tutorial_dialog.py
+++ b/src/vasoanalyzer/ui/dialogs/tutorial_dialog.py
@@ -36,7 +36,7 @@ class TutorialDialog(QDialog):
             "5. <b>Customize Your View</b>"
             "<br>• Zoom and pan the plot by click-dragging on the axes."
             "<br>• Go to <b>View → Plot Style</b> to adjust axis labels, fonts, and line styles."
-            "<br>• Drag the splitter bars to resize the trace, image viewer, and table."
+            "<br>• Resize panels using standard window controls."
             "<br><br>"
             "6. <b>Save & Pick Up Later</b>"
             "<br>• Click the <b>Save</b> icon (or press ⌘ S) to store both your data <b>and</b> exactly how you’ve arranged the window."

--- a/src/vasoanalyzer/ui/main_window.py
+++ b/src/vasoanalyzer/ui/main_window.py
@@ -43,7 +43,6 @@ from PyQt5.QtWidgets import (
     QTreeWidget,
     QTreeWidgetItem,
     QStyle,
-    QSplitter,
 )
 
 from PyQt5.QtGui import QPixmap, QImage, QIcon, QCursor
@@ -1274,15 +1273,14 @@ class VasoAnalyzerApp(QMainWindow):
         right_widget = QWidget()
         right_widget.setLayout(right_layout)
 
-        splitter = QSplitter(Qt.Horizontal)
-        splitter.addWidget(left_widget)
-        splitter.addWidget(right_widget)
-        splitter.setStretchFactor(0, 4)
-        splitter.setStretchFactor(1, 1)
+        content_layout = QHBoxLayout()
+        content_layout.setSpacing(0)
+        content_layout.setContentsMargins(0, 0, 0, 0)
+        content_layout.addWidget(left_widget, stretch=4)
+        content_layout.addWidget(right_widget, stretch=1)
 
-        self.splitter = splitter
         self.default_main_layout = self.rebuild_default_main_layout()
-        self.main_layout.addWidget(splitter)
+        self.main_layout.addLayout(content_layout)
 
         # ===== Canvas Interactions =====
         self.canvas.mpl_connect("draw_event", self.update_event_label_positions)
@@ -3067,18 +3065,17 @@ class VasoAnalyzerApp(QMainWindow):
         right_layout.addLayout(snapshot_layout)
         right_layout.addWidget(self.event_table)
 
-        # Combine left + right into splitter for user-resizable panels
         left_widget = QWidget()
         left_widget.setLayout(left_layout)
         right_widget = QWidget()
         right_widget.setLayout(right_layout)
 
-        splitter = QSplitter(Qt.Horizontal)
-        splitter.addWidget(left_widget)
-        splitter.addWidget(right_widget)
-        splitter.setStretchFactor(0, 4)
-        splitter.setStretchFactor(1, 1)
-        return splitter
+        layout = QHBoxLayout()
+        layout.setSpacing(0)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(left_widget, stretch=4)
+        layout.addWidget(right_widget, stretch=1)
+        return layout
 
     # [K] ========================= EXPORT LOGIC (CSV, FIG) ==============================
     def auto_export_table(self):


### PR DESCRIPTION
## Summary
- replace QSplitter usage with static QHBoxLayout in main window and dual view
- update tutorial text regarding resizing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684ed799b58483268baf86ade11dd52f