### PR TITLE
Allow manual resizing for event tables

### DIFF
--- a/src/vasoanalyzer/dual_view_panel.py
+++ b/src/vasoanalyzer/dual_view_panel.py
@@ -1,6 +1,7 @@
 from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QSlider, QTableWidget,
-    QTableWidgetItem, QAbstractItemView, QPushButton, QFileDialog, QToolButton, QMessageBox
+    QTableWidgetItem, QAbstractItemView, QPushButton, QFileDialog,
+    QToolButton, QMessageBox, QHeaderView
 )
 from PyQt5.QtWidgets import QLabel
 from PyQt5.QtGui import QIcon
@@ -112,6 +113,12 @@ class DataViewPanel(QWidget):
         self.event_table.setHorizontalHeaderLabels(["Event", "Time (s)", "ID (µm)"])
         self.event_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self.event_table.setSelectionBehavior(QAbstractItemView.SelectRows)
+
+        header = self.event_table.horizontalHeader()
+        header.setStretchLastSection(False)
+        for i in range(3):
+            header.setSectionResizeMode(i, QHeaderView.Interactive)
+        header.setDefaultSectionSize(100)
 
         # --- Layout ---
         main_layout = QVBoxLayout(self)

--- a/src/vasoanalyzer/excel_mapper.py
+++ b/src/vasoanalyzer/excel_mapper.py
@@ -1,6 +1,7 @@
 from PyQt5.QtWidgets import (
     QDialog, QVBoxLayout, QLabel, QPushButton, QFileDialog, QComboBox,
-    QTableWidget, QTableWidgetItem, QHBoxLayout, QMessageBox, QFrame
+    QTableWidget, QTableWidgetItem, QHBoxLayout, QMessageBox, QFrame,
+    QHeaderView
 )
 from openpyxl import load_workbook
 from openpyxl.utils import column_index_from_string, get_column_letter
@@ -80,7 +81,11 @@ class ExcelMappingDialog(QDialog):
         self.event_table.setEditTriggers(QTableWidget.NoEditTriggers)
         self.event_table.cellClicked.connect(self.map_event_to_excel)
         self.event_table.setMinimumWidth(420)
-        self.event_table.horizontalHeader().setStretchLastSection(True)
+        header = self.event_table.horizontalHeader()
+        header.setStretchLastSection(False)
+        for i in range(4):
+            header.setSectionResizeMode(i, QHeaderView.Interactive)
+        header.setDefaultSectionSize(100)
         self.layout.addWidget(self.event_table)
         self.populate_event_table()
 
@@ -88,7 +93,10 @@ class ExcelMappingDialog(QDialog):
         self.preview_table = QTableWidget()
         self.preview_table.setEditTriggers(QTableWidget.NoEditTriggers)
         self.preview_table.setMinimumWidth(420)
-        self.preview_table.horizontalHeader().setStretchLastSection(True)
+        pheader = self.preview_table.horizontalHeader()
+        pheader.setStretchLastSection(False)
+        pheader.setSectionResizeMode(QHeaderView.Interactive)
+        pheader.setDefaultSectionSize(100)
         self.layout.addWidget(self.preview_table)
 
         self.button_layout = QHBoxLayout()

--- a/src/vasoanalyzer/ui/main_window.py
+++ b/src/vasoanalyzer/ui/main_window.py
@@ -1246,9 +1246,9 @@ class VasoAnalyzerApp(QMainWindow):
 
         header = self.event_table.horizontalHeader()
         header.setStretchLastSection(False)
-        header.setSectionResizeMode(0, QHeaderView.ResizeToContents)
-        for i in range(1, 4):
-            header.setSectionResizeMode(i, QHeaderView.Stretch)
+        for i in range(4):
+            header.setSectionResizeMode(i, QHeaderView.Interactive)
+        header.setDefaultSectionSize(100)
         self.event_table.cellClicked.connect(self.table_row_clicked)
         self.event_table.itemChanged.connect(self.handle_table_edit)
         self.event_table.setContextMenuPolicy(Qt.CustomContextMenu)


### PR DESCRIPTION
## Summary
- configure event table headers so all columns start equal and can be resized
- apply same behavior in Excel mapper and dual view panel

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684ef5d8a52483268288e6a158f5635d