### PR TITLE
Fix project save crash and legacy event names

### DIFF
--- a/src/vasoanalyzer/event_loader.py
+++ b/src/vasoanalyzer/event_loader.py
@@ -36,10 +36,21 @@ def load_events(file_path):
 
     df = pd.read_csv(file_path, delimiter=delimiter)
 
-    # Auto-detect columns
-    label_col = next((col for col in df.columns if "label" in col.lower()), df.columns[0])
-    time_col = next((col for col in df.columns if "time" in col.lower()), df.columns[1])
-    frame_col = next((col for col in df.columns if "frame" in col.lower()), None)
+    # Auto-detect columns with fallback for legacy headers
+    def _find_col(keywords, default=None):
+        for col in df.columns:
+            normalized = col.lower().replace(" ", "")
+            if any(k in normalized for k in keywords):
+                return col
+        return default
+
+    label_col = _find_col(["label", "event", "name"], df.columns[0])
+    if len(df.columns) > 1:
+        default_time = df.columns[1]
+    else:
+        default_time = df.columns[0]
+    time_col = _find_col(["time"], default_time)
+    frame_col = _find_col(["frame"])
 
     # Convert time to seconds
     time_series = df[time_col]

--- a/src/vasoanalyzer/ui/main_window.py
+++ b/src/vasoanalyzer/ui/main_window.py
@@ -59,7 +59,13 @@ from vasoanalyzer.theme_manager import (
     apply_light_theme,
     css_rgba_to_mpl,
 )
-from vasoanalyzer.project import Project, Experiment, SampleN, export_sample
+from vasoanalyzer.project import (
+    Project,
+    Experiment,
+    SampleN,
+    export_sample,
+    save_project,
+)
 from vasoanalyzer.project_controller import open_project, save_project_file
 from vasoanalyzer.ui.dialogs.axis_settings_dialog import AxisSettingsDialog
 from vasoanalyzer.ui.dialogs.plot_style_dialog import PlotStyleDialog

--- a/tests/test_event_file_detection.py
+++ b/tests/test_event_file_detection.py
@@ -54,3 +54,15 @@ def test_load_events_numeric_strings(tmp_path):
     pd.DataFrame({"Label": ["A", "B"], "Time": ["1", "2"]}).to_csv(event_path, index=False)
     labels, times, frames = load_events(str(event_path))
     assert times == [1.0, 2.0]
+
+
+def test_load_events_legacy_event_column(tmp_path):
+    event_path = tmp_path / "events_legacy.csv"
+    # Legacy tables often place the time column first
+    df = pd.DataFrame({"Time": [0.5, 1.0], "Event": ["A", "B"]})
+    df.to_csv(event_path, index=False)
+
+    labels, times, frames = load_events(str(event_path))
+
+    assert labels == ["A", "B"]
+    assert times == [0.5, 1.0]


### PR DESCRIPTION
## Summary
- import `save_project` so adding samples works
- detect `Event` and `Name` columns in legacy event tables
- add regression test for legacy event table format

## Testing
- `pytest -q` *(fails: ModuleNotFoundError due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684f437d49308326a7927f9f0988bd03