### PR TITLE
Fix event label detection

### DIFF
--- a/src/vasoanalyzer/event_loader.py
+++ b/src/vasoanalyzer/event_loader.py
@@ -2,6 +2,7 @@
 
 import csv
 import os
+import re
 import pandas as pd
 
 
@@ -37,11 +38,17 @@ def load_events(file_path):
     df = pd.read_csv(file_path, delimiter=delimiter)
 
     # Auto-detect columns with fallback for legacy headers
+    def _normalize(col: str) -> str:
+        """Return a simplified column name for matching."""
+        return re.sub(r"[^a-z0-9]", "", col.lower())
+
     def _find_col(keywords, default=None):
-        for col in df.columns:
-            normalized = col.lower().replace(" ", "")
-            if any(k in normalized for k in keywords):
-                return col
+        normed_cols = {col: _normalize(col) for col in df.columns}
+        for col, norm in normed_cols.items():
+            for kw in keywords:
+                kw_norm = _normalize(kw)
+                if norm == kw_norm or norm.startswith(kw_norm):
+                    return col
         return default
 
     label_col = _find_col(["label", "event", "name"], df.columns[0])

--- a/tests/test_event_file_detection.py
+++ b/tests/test_event_file_detection.py
@@ -66,3 +66,18 @@ def test_load_events_legacy_event_column(tmp_path):
 
     assert labels == ["A", "B"]
     assert times == [0.5, 1.0]
+
+
+def test_load_events_frame_column_not_label(tmp_path):
+    event_path = tmp_path / "events_with_frame.csv"
+    df = pd.DataFrame({
+        "Time": [0.1, 0.2],
+        "Frame Number": [1, 2],
+        "Label": ["A", "B"],
+    })
+    df.to_csv(event_path, index=False)
+
+    labels, times, frames = load_events(str(event_path))
+
+    assert labels == ["A", "B"]
+    assert frames == [1, 2]


### PR DESCRIPTION
## Summary
- improve column detection in `load_events`
- ensure frame column doesn't override label column when loading legacy events

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684f4b27074c8326bb7dbf53bac46987