### PR TITLE
Fix trace load order

### DIFF
--- a/src/vasoanalyzer/ui/main_window.py
+++ b/src/vasoanalyzer/ui/main_window.py
@@ -1410,6 +1410,8 @@ class VasoAnalyzerApp(QMainWindow):
         """Load a trace file and its matching events if available."""
 
         df = load_trace(trace_path)
+        # Ensure trace data is available before any UI updates
+        self.trace_data = df
         self.trace_file_path = os.path.dirname(trace_path)
         trace_filename = os.path.basename(trace_path)
         self.trace_file_label.setText(f"🧪 {trace_filename}")


### PR DESCRIPTION
## Summary
- ensure `trace_data` is assigned before UI updates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684f5f80b0188326875cbd7e5b179a46