### PR TITLE
Add legacy header mapping for VasoAnalyzer

### DIFF
--- a/src/vasoanalyzer/event_loader.py
+++ b/src/vasoanalyzer/event_loader.py
@@ -6,6 +6,22 @@ import re
 import pandas as pd
 
 
+def _standardize_headers(df: pd.DataFrame) -> pd.DataFrame:
+    """Return ``df`` with legacy headers renamed to current names."""
+    rename_map = {}
+    for col in df.columns:
+        norm = col.lower().replace(" ", "")
+        if norm == "event":
+            rename_map[col] = "EventLabel"
+        elif norm in {"t(s)", "t", "ts"}:
+            rename_map[col] = "Time"
+        elif norm in {"diameterbefore", "diambefore"} or norm.startswith("diameterbefore"):
+            rename_map[col] = "DiamBefore"
+    if rename_map:
+        df = df.rename(columns=rename_map)
+    return df
+
+
 def load_events(file_path):
     """Return event labels, times and optional frames from a table file.
 
@@ -36,6 +52,9 @@ def load_events(file_path):
                 delimiter = ";"
 
     df = pd.read_csv(file_path, delimiter=delimiter)
+
+    # Normalize headers for legacy files
+    df = _standardize_headers(df)
 
     # Auto-detect columns with fallback for legacy headers
     def _normalize(col: str) -> str:

--- a/src/vasoanalyzer/project.py
+++ b/src/vasoanalyzer/project.py
@@ -5,6 +5,7 @@ from dataclasses import asdict, dataclass, field
 from typing import List, Optional
 
 import pandas as pd
+from .event_loader import _standardize_headers
 
 __all__ = [
     "Project",
@@ -82,6 +83,8 @@ def sample_from_dict(data: dict) -> SampleN:
     events_data = data.get("events_data")
     if isinstance(events_data, dict):
         events_data = pd.DataFrame(events_data)
+    if isinstance(events_data, pd.DataFrame):
+        events_data = _standardize_headers(events_data)
 
     return SampleN(
         name=data.get("name", ""),

--- a/tests/test_event_file_detection.py
+++ b/tests/test_event_file_detection.py
@@ -81,3 +81,20 @@ def test_load_events_frame_column_not_label(tmp_path):
 
     assert labels == ["A", "B"]
     assert frames == [1, 2]
+
+
+def test_load_events_header_aliases(tmp_path):
+    event_path = tmp_path / "legacy.csv"
+    df = pd.DataFrame({
+        "event": ["A", "B"],
+        "t (s)": [0.1, 0.2],
+        "diameter before": [10, 11],
+        "Frame": [1, 2],
+    })
+    df.to_csv(event_path, index=False)
+
+    labels, times, frames = load_events(str(event_path))
+
+    assert labels == ["A", "B"]
+    assert times == [0.1, 0.2]
+    assert frames == [1, 2]


### PR DESCRIPTION
## Summary
- normalize event table headers so legacy files load
- map headers when loading embedded project data
- test header aliasing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68501809f5888326897548efad8bc12b