### PR TITLE
Support legacy 'T (s)' header

### DIFF
--- a/src/vasoanalyzer/trace_loader.py
+++ b/src/vasoanalyzer/trace_loader.py
@@ -49,7 +49,11 @@ def load_trace(file_path):
     outer_col = None
     for c in df.columns:
         norm = _normalize(c)
-        if time_col is None and ("time" in norm or "sec" in norm or norm == "t"):
+        if time_col is None and (
+            "time" in norm
+            or "sec" in norm
+            or norm in {"t", "ts"}
+        ):
             time_col = c
         if diam_col is None and (
             ("inner" in norm and "diam" in norm)

--- a/tests/test_trace_loader.py
+++ b/tests/test_trace_loader.py
@@ -44,3 +44,13 @@ def test_load_trace_outer_diameter(tmp_path):
     assert "Outer Diameter" in loaded.columns
     assert loaded["Outer Diameter"].tolist() == [15, 16, 17]
 
+
+def test_load_trace_legacy_time_column(tmp_path):
+    csv_path = tmp_path / "legacy.csv"
+    df = pd.DataFrame({"T (s)": [0, 1, 2], "ID": [5, 6, 7]})
+    df.to_csv(csv_path, index=False)
+
+    loaded = load_trace(str(csv_path))
+    assert loaded["Time (s)"].tolist() == [0, 1, 2]
+    assert loaded["Inner Diameter"].tolist() == [5, 6, 7]
+


### PR DESCRIPTION
## Summary
- handle `T (s)` and `t (s)` as Time column aliases
- test legacy time header handling

## Testing
- `pytest -q tests/test_trace_loader.py::test_load_trace_legacy_time_column -vv` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement matplotlib>=3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68501bd09ff883269a2fbb4de9566a89