### PR TITLE
Remove outer diameter functionality

### DIFF
--- a/src/vasoanalyzer/dual_view_panel.py
+++ b/src/vasoanalyzer/dual_view_panel.py
@@ -84,14 +84,6 @@ class DataViewPanel(QWidget):
             grid_btn.setChecked(True)
             grid_btn.clicked.connect(self._toggle_grid)
             self.toolbar.insertWidget(visible[7], grid_btn)
-            # Inject Outer Diameter toggle
-            outer_btn = QToolButton()
-            outer_btn.setIcon(QIcon(self.window().icon_path("Subplots.svg")))
-            outer_btn.setToolTip("Show Outer Diameter")
-            outer_btn.setCheckable(True)
-            outer_btn.setChecked(False)
-            outer_btn.clicked.connect(self._toggle_outer_diameter)
-            self.toolbar.insertWidget(visible[7], outer_btn)
             # Override save
             save_btn = visible[7]
             save_btn.setToolTip("Save As… Export plot or save to N")
@@ -175,7 +167,6 @@ class DataViewPanel(QWidget):
         self.event_table_data = []
         self.slider_marker = None
         self.grid_visible = True
-        self.show_outer = False
         
         # Dual Clearing
         self._original_title = self.ax.get_title()
@@ -237,15 +228,10 @@ class DataViewPanel(QWidget):
         self.ax.clear()
         self.event_text_objects = []                  # ← reset the list
         t = self.trace_data["Time (s)"]
-        col = (
-            "Outer Diameter"
-            if self.show_outer and "Outer Diameter" in self.trace_data
-            else "Inner Diameter"
-        )
-        d = self.trace_data[col]
+        d = self.trace_data["Inner Diameter"]
         self.ax.plot(t, d, "k-", linewidth=1.5)
         self.ax.set_xlabel("Time (s)")
-        self.ax.set_ylabel(f"{col} (µm)")
+        self.ax.set_ylabel("Inner Diameter (µm)")
         self.ax.grid(self.grid_visible)
 
         for lbl, t_evt in zip(self.event_labels, self.event_times):
@@ -267,12 +253,7 @@ class DataViewPanel(QWidget):
         # assume an offset of 2 seconds
         offset = 2.0
         times = self.trace_data["Time (s)"].values
-        col = (
-            "Outer Diameter"
-            if self.show_outer and "Outer Diameter" in self.trace_data
-            else "Inner Diameter"
-        )
-        diam  = self.trace_data[col].values
+        diam  = self.trace_data["Inner Diameter"].values
         self.event_table_data = []
         for i, (lbl, t_evt) in enumerate(zip(self.event_labels, self.event_times)):
             if i < len(self.event_times) - 1:
@@ -284,7 +265,7 @@ class DataViewPanel(QWidget):
             sampled_dia = float(diam[idx])
             self.event_table_data.append((lbl, round(t_evt,2), round(sampled_dia,2)))
 
-        header = ["Event", "Time (s)", "OD (µm)" if self.show_outer else "ID (µm)"]
+        header = ["Event", "Time (s)", "ID (µm)"]
         self.event_table.setHorizontalHeaderLabels(header)
         self.event_table.setRowCount(len(self.event_table_data))
         for row, (lbl, t_evt, idval) in enumerate(self.event_table_data):
@@ -405,18 +386,12 @@ class DataViewPanel(QWidget):
 
         # find nearest sample
         times = self.trace_data["Time (s)"].values
-        col = (
-            "Outer Diameter"
-            if self.show_outer and "Outer Diameter" in self.trace_data
-            else "Inner Diameter"
-        )
-        diams = self.trace_data[col].values
+        diams = self.trace_data["Inner Diameter"].values
         idx = int(np.argmin(np.abs(times - event.xdata)))
         t_near = times[idx]
         d_near = diams[idx]
 
-        label = "OD" if self.show_outer and "Outer Diameter" in self.trace_data else "ID"
-        self.hover_label.setText(f"Time: {t_near:.2f} s\n{label}: {d_near:.2f} µm")
+        self.hover_label.setText(f"Time: {t_near:.2f} s\nID: {d_near:.2f} µm")
 
         # now position it using the canvas geometry + cursor offset
         cr = self.canvas.geometry()
@@ -449,10 +424,6 @@ class DataViewPanel(QWidget):
         self.ax.grid(self.grid_visible, color="#CCC")
         self.canvas.draw_idle()
 
-    def _toggle_outer_diameter(self):
-        self.show_outer = not self.show_outer
-        self.update_plot()
-        self.populate_table()
 
     def _export_high_res_plot(self):
         file_path, _ = QFileDialog.getSaveFileName(

--- a/src/vasoanalyzer/trace_loader.py
+++ b/src/vasoanalyzer/trace_loader.py
@@ -46,7 +46,6 @@ def load_trace(file_path):
     # Locate time and diameter columns using flexible matching for legacy files
     time_col = None
     diam_col = None
-    outer_col = None
     for c in df.columns:
         norm = _normalize(c)
         if time_col is None and (
@@ -61,14 +60,7 @@ def load_trace(file_path):
             or norm in {"id", "diameter"}
         ):
             diam_col = c
-        if outer_col is None and (
-            "outerdiameter" in norm
-            or "outerdiam" in norm
-            or norm == "od"
-            or ("outer" in norm and "diam" in norm)
-        ):
-            outer_col = c
-        if time_col and diam_col and outer_col:
+        if time_col and diam_col:
             break
 
     if time_col is None or diam_col is None or time_col == diam_col:
@@ -76,8 +68,6 @@ def load_trace(file_path):
 
     # Rename to standardized column names
     rename_map = {time_col: "Time (s)", diam_col: "Inner Diameter"}
-    if outer_col is not None and outer_col not in {time_col, diam_col}:
-        rename_map[outer_col] = "Outer Diameter"
     df = df.rename(columns=rename_map)
     df = df.loc[:, ~df.columns.duplicated()]
 
@@ -85,6 +75,6 @@ def load_trace(file_path):
     df["Time (s)"] = pd.to_numeric(df["Time (s)"], errors="coerce")
     df["Inner Diameter"] = pd.to_numeric(df["Inner Diameter"], errors="coerce")
     if "Outer Diameter" in df.columns:
-        df["Outer Diameter"] = pd.to_numeric(df["Outer Diameter"], errors="coerce")
+        df = df.drop(columns=["Outer Diameter"])
 
     return df

--- a/src/vasoanalyzer/ui/main_window.py
+++ b/src/vasoanalyzer/ui/main_window.py
@@ -113,7 +113,6 @@ class VasoAnalyzerApp(QMainWindow):
         self.excel_auto_path = None  # Path to Excel file for auto-update
         self.excel_auto_column = None  # Column letter to use for auto-update
         self.grid_visible = True  # Track grid visibility
-        self.show_outer = False  # Whether to display outer diameter
         self.recent_files = []
         self.settings = QSettings("TykockiLab", "VasoAnalyzer")
         self.load_recent_files()
@@ -688,10 +687,6 @@ class VasoAnalyzerApp(QMainWindow):
         snap_vw.triggered.connect(self.toggle_snapshot_viewer)
         self.showhide_menu.addAction(evt_tbl)
         self.showhide_menu.addAction(snap_vw)
-        outer_diam = QAction("Show Outer Diameter", self, checkable=True)
-        outer_diam.triggered.connect(self.toggle_outer_diameter)
-        self.showhide_menu.addAction(outer_diam)
-        self.outer_diam_action = outer_diam
 
         view_menu.addSeparator()
 
@@ -952,11 +947,6 @@ class VasoAnalyzerApp(QMainWindow):
         self.snapshot_label.setVisible(checked)
         self.slider.setVisible(checked)
 
-    def toggle_outer_diameter(self, checked: bool):
-        """Switch between inner and outer diameter display."""
-        self.show_outer = checked
-        self.update_plot()
-        self.populate_table()
 
     def toggle_fullscreen(self):
         if self.isFullScreen():
@@ -1488,12 +1478,7 @@ class VasoAnalyzerApp(QMainWindow):
 
     def populate_table(self):
         self.event_table.blockSignals(True)
-        header = [
-            "Event",
-            "Time (s)",
-            "OD (µm)" if self.show_outer else "ID (µm)",
-            "Frame",
-        ]
+        header = ["Event", "Time (s)", "ID (µm)", "Frame"]
         self.event_table.setHorizontalHeaderLabels(header)
         self.event_table.setRowCount(len(self.event_table_data))
         for row, (label, t, idval, frame) in enumerate(self.event_table_data):
@@ -1760,13 +1745,8 @@ class VasoAnalyzerApp(QMainWindow):
         self.event_table_data = []
 
         if self.trace_data is not None and self.event_times:
-            col = (
-                "Outer Diameter"
-                if self.show_outer and "Outer Diameter" in self.trace_data
-                else "Inner Diameter"
-            )
             arr_t = self.trace_data["Time (s)"].values
-            arr_d = self.trace_data[col].values
+            arr_d = self.trace_data["Inner Diameter"].values
             for lbl, t, fr in zip(
                 self.event_labels,
                 self.event_times,
@@ -2175,15 +2155,10 @@ class VasoAnalyzerApp(QMainWindow):
 
         # Plot trace and keep a handle for .contains()
         t = self.trace_data["Time (s)"]
-        col = (
-            "Outer Diameter"
-            if self.show_outer and "Outer Diameter" in self.trace_data
-            else "Inner Diameter"
-        )
-        d = self.trace_data[col]
+        d = self.trace_data["Inner Diameter"]
         (self.trace_line,) = self.ax.plot(t, d, "k-", linewidth=1.5)
         self.ax.set_xlabel("Time (s)")
-        self.ax.set_ylabel(f"{col} (µm)")
+        self.ax.set_ylabel("Inner Diameter (µm)")
         self.ax.grid(True, color=CURRENT_THEME["grid_color"])
 
         # Plot events if available
@@ -2192,12 +2167,7 @@ class VasoAnalyzerApp(QMainWindow):
             self.event_table_data = []
             offset_sec = 2
             nEv = len(self.event_times)
-            col = (
-                "Outer Diameter"
-                if self.show_outer and "Outer Diameter" in self.trace_data
-                else "Inner Diameter"
-            )
-            diam_trace = self.trace_data[col]
+            diam_trace = self.trace_data["Inner Diameter"]
             time_trace = self.trace_data["Time (s)"]
 
             for i in range(nEv):

--- a/tests/test_trace_loader.py
+++ b/tests/test_trace_loader.py
@@ -29,7 +29,7 @@ def test_load_trace_duplicate_columns(tmp_path):
     assert loaded["Inner Diameter"].tolist() == [5, 6]
 
 
-def test_load_trace_outer_diameter(tmp_path):
+def test_load_trace_ignores_outer_diameter(tmp_path):
     csv_path = tmp_path / "outer.csv"
     df = pd.DataFrame(
         {
@@ -41,8 +41,7 @@ def test_load_trace_outer_diameter(tmp_path):
     df.to_csv(csv_path, index=False)
 
     loaded = load_trace(str(csv_path))
-    assert "Outer Diameter" in loaded.columns
-    assert loaded["Outer Diameter"].tolist() == [15, 16, 17]
+    assert "Outer Diameter" not in loaded.columns
 
 
 def test_load_trace_legacy_time_column(tmp_path):

--- a/tests/test_update_plot.py
+++ b/tests/test_update_plot.py
@@ -47,27 +47,4 @@ def test_event_table_id_values(tmp_path):
     app.quit()
 
 
-def test_update_plot_outer_diameter(tmp_path):
-    os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
-    trace_path = tmp_path / 'trace.csv'
-    df_trace = pd.DataFrame(
-        {
-            'Time (s)': [0, 1, 2, 3],
-            'Inner Diameter': [10, 11, 12, 13],
-            'Outer Diameter': [20, 21, 22, 23],
-        }
-    )
-    df_trace.to_csv(trace_path, index=False)
-    event_path = tmp_path / 'trace_table.csv'
-    df_evt = pd.DataFrame({'label': ['A', 'B'], 'time': [1, 2]})
-    df_evt.to_csv(event_path, index=False)
-
-    app = QApplication.instance() or QApplication([])
-    gui = VasoAnalyzerApp()
-    gui.load_trace_and_events(str(trace_path))
-    gui.toggle_outer_diameter(True)
-
-    assert gui.event_table_data[0][2] == 20.0
-    assert gui.event_table_data[1][2] == 21.0
-    app.quit()
 


### PR DESCRIPTION
## Summary
- drop outer diameter column when loading traces
- always plot inner diameter values only
- remove outer-diameter UI controls and state
- adjust tests for new behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas, numpy, matplotlib)*

------
https://chatgpt.com/codex/tasks/task_e_685043c285708326955fe2eb9616070b