### PR TITLE
Fix inner diameter loading

### DIFF
--- a/src/vasoanalyzer/trace_loader.py
+++ b/src/vasoanalyzer/trace_loader.py
@@ -46,6 +46,9 @@ def load_trace(file_path):
     # Locate time and diameter columns using flexible matching for legacy files
     time_col = None
     diam_col = None
+    inner_candidates = []
+    diam_candidates = []
+
     for c in df.columns:
         norm = _normalize(c)
         if time_col is None and (
@@ -54,14 +57,16 @@ def load_trace(file_path):
             or norm in {"t", "ts"}
         ):
             time_col = c
-        if diam_col is None and (
-            ("inner" in norm and "diam" in norm)
-            or "diam" in norm
-            or norm in {"id", "diameter"}
-        ):
-            diam_col = c
-        if time_col and diam_col:
-            break
+
+        if "inner" in norm and "diam" in norm:
+            inner_candidates.append(c)
+        elif "diam" in norm or norm in {"id", "diameter"}:
+            diam_candidates.append(c)
+
+    if inner_candidates:
+        diam_col = inner_candidates[0]
+    elif diam_candidates:
+        diam_col = diam_candidates[0]
 
     if time_col is None or diam_col is None or time_col == diam_col:
         raise ValueError("Trace file must contain Time and Inner Diameter columns")

--- a/tests/test_trace_loader.py
+++ b/tests/test_trace_loader.py
@@ -44,6 +44,22 @@ def test_load_trace_ignores_outer_diameter(tmp_path):
     assert "Outer Diameter" not in loaded.columns
 
 
+def test_load_trace_prefers_inner_over_outer(tmp_path):
+    csv_path = tmp_path / "mixed.csv"
+    df = pd.DataFrame(
+        {
+            "Time": [0, 1, 2],
+            "Outer Diameter": [15, 16, 17],
+            "Inner Diameter": [10, 11, 12],
+        }
+    )
+    df.to_csv(csv_path, index=False)
+
+    loaded = load_trace(str(csv_path))
+    assert loaded["Inner Diameter"].tolist() == [10, 11, 12]
+    assert "Outer Diameter" not in loaded.columns
+
+
 def test_load_trace_legacy_time_column(tmp_path):
     csv_path = tmp_path / "legacy.csv"
     df = pd.DataFrame({"T (s)": [0, 1, 2], "ID": [5, 6, 7]})


### PR DESCRIPTION
## Summary
- ensure trace loader prefers the Inner Diameter column when both inner and outer diameter columns exist
- add regression test for inner/outer diameter selection

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685049034ffc83269f6130a7113fcaa6