### PR TITLE
Improve event label detection

### DIFF
--- a/src/vasoanalyzer/event_loader.py
+++ b/src/vasoanalyzer/event_loader.py
@@ -62,12 +62,23 @@ def load_events(file_path):
         return re.sub(r"[^a-z0-9]", "", col.lower())
 
     def _find_col(keywords, default=None):
+        """Return the column matching ``keywords`` with priority to exact names."""
         normed_cols = {col: _normalize(col) for col in df.columns}
-        for col, norm in normed_cols.items():
-            for kw in keywords:
-                kw_norm = _normalize(kw)
-                if norm == kw_norm or norm.startswith(kw_norm):
+
+        # 1) Look for exact keyword matches first
+        for kw in keywords:
+            kw_norm = _normalize(kw)
+            for col, norm in normed_cols.items():
+                if norm == kw_norm:
                     return col
+
+        # 2) Fallback to prefix matches (e.g. ``EventLabel`` for ``Event``)
+        for kw in keywords:
+            kw_norm = _normalize(kw)
+            for col, norm in normed_cols.items():
+                if norm.startswith(kw_norm):
+                    return col
+
         return default
 
     label_col = _find_col(["label", "event", "name"], df.columns[0])

--- a/tests/test_event_file_detection.py
+++ b/tests/test_event_file_detection.py
@@ -98,3 +98,18 @@ def test_load_events_header_aliases(tmp_path):
     assert labels == ["A", "B"]
     assert times == [0.1, 0.2]
     assert frames == [1, 2]
+
+
+def test_load_events_ignore_event_time(tmp_path):
+    """Label column should not confuse 'Event Time' for an event label."""
+    event_path = tmp_path / "complex.csv"
+    df = pd.DataFrame({
+        "Event Time": [0.1, 0.2],
+        "EventLabel": ["A", "B"],
+    })
+    df.to_csv(event_path, index=False)
+
+    labels, times, _ = load_events(str(event_path))
+
+    assert labels == ["A", "B"]
+    assert times == [0.1, 0.2]


### PR DESCRIPTION
## Summary
- avoid misidentifying the label column when loading event tables
- add regression test for Event Time column handling

## Testing
- `pytest tests/test_event_file_detection.py::test_load_events_ignore_event_time -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68504a6cb92883268a8a17cb7f00d2ca