### PR TITLE
Handle headerless event CSV

### DIFF
--- a/src/vasoanalyzer/event_loader.py
+++ b/src/vasoanalyzer/event_loader.py
@@ -53,6 +53,21 @@ def load_events(file_path):
 
     df = pd.read_csv(file_path, delimiter=delimiter)
 
+    def _looks_like_number_or_time(val: str) -> bool:
+        """Return ``True`` if ``val`` resembles a numeric value or timestamp."""
+        s = str(val).strip()
+        if not s:
+            return False
+        if re.fullmatch(r"[-+]?\d*(?:\.\d+)?(?:e[-+]?\d+)?", s):
+            return True
+        if re.fullmatch(r"\d{1,2}(?::\d{2}){1,2}(?:\.\d+)?", s):
+            return True
+        return False
+
+    if any(_looks_like_number_or_time(c) for c in df.columns):
+        df = pd.read_csv(file_path, delimiter=delimiter, header=None)
+        df.columns = [f"col{i}" for i in range(df.shape[1])]
+
     # Normalize headers for legacy files
     df = _standardize_headers(df)
 

--- a/tests/test_event_file_detection.py
+++ b/tests/test_event_file_detection.py
@@ -113,3 +113,13 @@ def test_load_events_ignore_event_time(tmp_path):
 
     assert labels == ["A", "B"]
     assert times == [0.1, 0.2]
+
+
+def test_load_events_no_headers(tmp_path):
+    event_path = tmp_path / "no_headers.csv"
+    pd.DataFrame([["A", 0.1], ["B", 0.2]]).to_csv(event_path, index=False, header=False)
+
+    labels, times, _ = load_events(str(event_path))
+
+    assert labels == ["A", "B"]
+    assert times == [0.1, 0.2]


### PR DESCRIPTION
## Summary
- detect headerless CSVs in `load_events`
- add a regression test for no-header event files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6850539ed50c83269553b7fca8363c58