### PR TITLE
Add import logging

### DIFF
--- a/src/vasoanalyzer/event_loader.py
+++ b/src/vasoanalyzer/event_loader.py
@@ -3,7 +3,10 @@
 import csv
 import os
 import re
+import logging
 import pandas as pd
+
+log = logging.getLogger(__name__)
 
 
 def _standardize_headers(df: pd.DataFrame) -> pd.DataFrame:
@@ -37,6 +40,8 @@ def load_events(file_path):
         pandas.errors.ParserError: If the file cannot be parsed.
         ValueError: If time values cannot be converted to seconds.
     """
+
+    log.info("Loading events from %s", file_path)
 
     # Auto-detect delimiter using csv.Sniffer
     with open(file_path, "r", encoding="utf-8-sig") as f:
@@ -121,6 +126,7 @@ def load_events(file_path):
     if frame_col:
         frames = df[frame_col].tolist()
 
+    log.info("Loaded %d events", len(labels))
     return labels, times, frames
 
 

--- a/src/vasoanalyzer/tiff_loader.py
+++ b/src/vasoanalyzer/tiff_loader.py
@@ -70,6 +70,8 @@ def load_tiff(file_path, max_frames=300, metadata=True):
         OSError: If the file cannot be read as a TIFF.
     """
 
+    log.info("Loading TIFF from %s", file_path)
+
     frames = []
     frames_metadata = []
 
@@ -85,6 +87,7 @@ def load_tiff(file_path, max_frames=300, metadata=True):
             else:
                 for frame in frames_array:
                     frames.append(np.array(frame))
+            log.info("Loaded %d preview frames", len(frames))
             return frames, frames_metadata
 
         for i in range(0, total_frames, skip):
@@ -109,10 +112,12 @@ def load_tiff(file_path, max_frames=300, metadata=True):
 
             frames_metadata.append(frame_meta)
 
+    log.info("Loaded %d frames", len(frames))
     return frames, frames_metadata
 
 
 def load_tiff_preview(file_path, max_frames=300):
     """Fast loading without metadata for quick previews."""
 
+    log.info("Loading TIFF preview from %s", file_path)
     return load_tiff(file_path, max_frames=max_frames, metadata=False)

--- a/src/vasoanalyzer/trace_event_loader.py
+++ b/src/vasoanalyzer/trace_event_loader.py
@@ -1,7 +1,10 @@
 import os
 import numpy as np
+import logging
 from .trace_loader import load_trace
 from .event_loader import load_events, find_matching_event_file
+
+log = logging.getLogger(__name__)
 
 
 def load_trace_and_events(trace_path: str, events_path: str | None = None):
@@ -22,14 +25,21 @@ def load_trace_and_events(trace_path: str, events_path: str | None = None):
         The trace DataFrame followed by event labels, times, frame indices (or
         ``None`` if unavailable) and the diameter at each event time.
     """
+    log.info("Loading trace and events for %s", trace_path)
     df = load_trace(trace_path)
 
     if events_path is None:
         events_path = find_matching_event_file(trace_path)
 
+    if events_path and os.path.exists(events_path):
+        log.info("Found event file: %s", events_path)
+    else:
+        log.info("No event file found for %s", trace_path)
+
     labels, times, frames, diam = [], [], None, []
     if events_path and os.path.exists(events_path):
         labels, times, frames = load_events(events_path)
+        log.info("Loaded %d events", len(labels))
         if frames is None:
             arr_t = df["Time (s)"].values
             frames = [int(np.argmin(np.abs(arr_t - t))) for t in times]
@@ -37,6 +47,7 @@ def load_trace_and_events(trace_path: str, events_path: str | None = None):
         arr_d = df["Inner Diameter"].values
         diam = [float(arr_d[int(np.argmin(np.abs(arr_t - t)))]) for t in times]
 
+    log.info("Trace and events loaded: %d events", len(labels))
     return df, labels, times, frames, diam
 
 __all__ = ["load_trace_and_events"]

--- a/src/vasoanalyzer/trace_loader.py
+++ b/src/vasoanalyzer/trace_loader.py
@@ -3,8 +3,11 @@
 
 import csv
 import re
+import logging
 
 import pandas as pd
+
+log = logging.getLogger(__name__)
 
 
 def load_trace(file_path):
@@ -21,6 +24,8 @@ def load_trace(file_path):
         ValueError: If no time or inner diameter column can be found.
         pandas.errors.ParserError: If the CSV cannot be parsed.
     """
+
+    log.info("Loading trace from %s", file_path)
 
     # Auto-detect delimiter using the CSV sniffer
     with open(file_path, "r", encoding="utf-8-sig") as f:
@@ -82,4 +87,5 @@ def load_trace(file_path):
     if "Outer Diameter" in df.columns:
         df = df.drop(columns=["Outer Diameter"])
 
+    log.info("Loaded trace with %d rows", len(df))
     return df

--- a/src/vasoanalyzer/ui/main_window.py
+++ b/src/vasoanalyzer/ui/main_window.py
@@ -279,6 +279,7 @@ class VasoAnalyzerApp(QMainWindow):
 
     def load_sample_into_view(self, sample: SampleN):
         """Load a sample's trace and events into the main view."""
+        log.info("Loading sample %s", sample.name)
         try:
             if sample.trace_data is not None:
                 trace = sample.trace_data.copy()
@@ -319,6 +320,7 @@ class VasoAnalyzerApp(QMainWindow):
         self.update_plot()
         self.compute_frame_trace_indices()
         self.load_project_events(labels, times, frames, diam)
+        log.info("Sample loaded with %d events", len(labels))
 
     def show_project_context_menu(self, pos):
         item = self.project_tree.itemAt(pos)
@@ -399,6 +401,7 @@ class VasoAnalyzerApp(QMainWindow):
             save_project(self.current_project, self.current_project.path)
 
     def load_data_into_sample(self, sample: SampleN):
+        log.info("Loading data into sample %s", sample.name)
         trace_path, _ = QFileDialog.getOpenFileName(
             self, "Select Trace File", "", "CSV Files (*.csv)"
         )
@@ -417,6 +420,8 @@ class VasoAnalyzerApp(QMainWindow):
             sample.events_path = event_path
 
         self.refresh_project_tree()
+
+        log.info("Sample %s updated with data", sample.name)
 
         if self.current_project and self.current_project.path:
             save_project(self.current_project, self.current_project.path)
@@ -1399,7 +1404,7 @@ class VasoAnalyzerApp(QMainWindow):
     # [D] ========================= FILE LOADERS: TRACE / EVENTS / TIFF =====================
     def load_trace_and_event_files(self, trace_path):
         """Load a trace file and its matching events if available."""
-
+        log.info("Importing trace file %s", trace_path)
         df, labels, times, frames, diam = load_trace_and_events(trace_path)
 
         self.trace_data = df
@@ -1420,6 +1425,8 @@ class VasoAnalyzerApp(QMainWindow):
         self.compute_frame_trace_indices()
         self.update_scroll_slider()
         self.style_event_table()
+
+        log.info("Trace import complete with %d events", len(labels))
 
         return df
 


### PR DESCRIPTION
## Summary
- add debug logging to event loader, trace loader and tiff loader
- report trace+event loading progress in `trace_event_loader`
- log when files are imported in the main window

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas, numpy and matplotlib)*

------
https://chatgpt.com/codex/tasks/task_e_6850559323c08326a813ced0056484f3