### PR TITLE
Add test for event label column population

### DIFF
--- a/tests/test_update_plot.py
+++ b/tests/test_update_plot.py
@@ -47,4 +47,29 @@ def test_event_table_id_values(tmp_path):
     app.quit()
 
 
+def test_event_labels_from_complex_file(tmp_path):
+    """Event column should use the actual event label, not the time."""
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+    trace_path = tmp_path / "trace.csv"
+    df_trace = pd.DataFrame({"Time (s)": [0, 1], "Inner Diameter": [10, 11]})
+    df_trace.to_csv(trace_path, index=False)
+
+    event_path = tmp_path / "trace_table.csv"
+    df_evt = pd.DataFrame({"Event": ["DrugA", "DrugB"], "Event Time": [0.5, 1.0]})
+    df_evt.to_csv(event_path, index=False)
+
+    app = QApplication.instance() or QApplication([])
+    gui = VasoAnalyzerApp()
+    gui.load_trace_and_events(str(trace_path))
+
+    labels = [row[0] for row in gui.event_table_data]
+    times = [row[1] for row in gui.event_table_data]
+
+    assert labels == ["DrugA", "DrugB"]
+    assert times == [0.5, 1.0]
+
+    app.quit()
+
+
 


### PR DESCRIPTION
## Summary
- verify that event labels populate correctly when a complex table has both 'Event' and 'Event Time' columns

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas, numpy, matplotlib)*

------
https://chatgpt.com/codex/tasks/task_e_68505ae4e2b08326a17a9c1dd9d4e02e