### PR TITLE
Improve header alias detection

### DIFF
--- a/src/vasoanalyzer/event_loader.py
+++ b/src/vasoanalyzer/event_loader.py
@@ -13,12 +13,20 @@ def _standardize_headers(df: pd.DataFrame) -> pd.DataFrame:
     """Return ``df`` with legacy headers renamed to current names."""
     rename_map = {}
     for col in df.columns:
-        norm = col.lower().replace(" ", "")
-        if norm == "event":
+        norm = (
+            col.lower()
+            .strip()
+            .replace(" ", "")
+            .replace("(", "")
+            .replace(")", "")
+        )
+        if norm in {"event", "label"}:
             rename_map[col] = "EventLabel"
-        elif norm in {"t(s)", "t", "ts"}:
+        elif norm in {"t", "ts", "time", "times", "timesec"}:
             rename_map[col] = "Time"
-        elif norm in {"diameterbefore", "diambefore"} or norm.startswith("diameterbefore"):
+        elif norm in {"diameterbefore", "diambefore", "id", "diameter"} or norm.startswith(
+            "diameterbefore"
+        ):
             rename_map[col] = "DiamBefore"
     if rename_map:
         df = df.rename(columns=rename_map)

--- a/tests/test_event_file_detection.py
+++ b/tests/test_event_file_detection.py
@@ -1,6 +1,10 @@
 import pandas as pd
 
-from vasoanalyzer.event_loader import find_matching_event_file, load_events
+from vasoanalyzer.event_loader import (
+    find_matching_event_file,
+    load_events,
+    _standardize_headers,
+)
 from vasoanalyzer.trace_loader import load_trace
 
 
@@ -123,3 +127,15 @@ def test_load_events_no_headers(tmp_path):
 
     assert labels == ["A", "B"]
     assert times == [0.1, 0.2]
+
+
+def test_standardize_headers_additional_aliases():
+    df = pd.DataFrame({
+        "Label": ["A"],
+        "Time (s)": [1.0],
+        "Diameter": [10],
+    })
+
+    std = _standardize_headers(df)
+
+    assert list(std.columns) == ["EventLabel", "Time", "DiamBefore"]


### PR DESCRIPTION
## Summary
- account for additional legacy column names in `_standardize_headers`
- test header renaming on new aliases

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas/matplotlib/numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68505e62b75c832681c5fafa687a21b6