### PR TITLE
Support legacy event labels stored in index

### DIFF
--- a/src/vasoanalyzer/event_loader.py
+++ b/src/vasoanalyzer/event_loader.py
@@ -84,6 +84,15 @@ def load_events(file_path):
     # Normalize headers for legacy files
     df = _standardize_headers(df)
 
+    if "EventLabel" in df.columns and df["EventLabel"].eq("-").all():
+        possible_labels = df.index.astype(str)
+        if any(
+            l != "-" and not l.replace(".", "", 1).isdigit()
+            for l in possible_labels
+        ):
+            df = df.reset_index()
+            df.rename(columns={"index": "EventLabel"}, inplace=True)
+
     # Auto-detect columns with fallback for legacy headers
     def _normalize(col: str) -> str:
         """Return a simplified column name for matching."""


### PR DESCRIPTION
## Summary
- update `load_events` to detect when labels are stored in the DataFrame index

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68507663ae108326a8414c02528406f9