### PR TITLE
Handle multiheader trace CSVs

### DIFF
--- a/src/vasoanalyzer/trace_loader.py
+++ b/src/vasoanalyzer/trace_loader.py
@@ -18,7 +18,8 @@ def load_trace(file_path):
 
     Returns:
         pandas.DataFrame: Data with ``"Time (s)"`` and ``"Inner Diameter"``
-        columns converted to numeric types.
+        columns converted to numeric types. Files with multiple header rows
+        are supported.
 
     Raises:
         ValueError: If no time or inner diameter column can be found.
@@ -40,7 +41,13 @@ def load_trace(file_path):
             else:
                 delimiter = ";"
 
-    df = pd.read_csv(file_path, delimiter=delimiter, encoding="utf-8-sig")
+    df = pd.read_csv(file_path, delimiter=delimiter, encoding="utf-8-sig", header=0)
+
+    if isinstance(df.columns, pd.MultiIndex):
+        df.columns = [
+            " ".join(str(part) for part in col if pd.notna(part))
+            for col in df.columns
+        ]
 
     # Drop any entirely empty columns that may appear due to malformed files
     df = df.dropna(axis=1, how="all")

--- a/tests/test_trace_loader.py
+++ b/tests/test_trace_loader.py
@@ -69,3 +69,18 @@ def test_load_trace_legacy_time_column(tmp_path):
     assert loaded["Time (s)"].tolist() == [0, 1, 2]
     assert loaded["Inner Diameter"].tolist() == [5, 6, 7]
 
+
+def test_load_trace_multiheader(tmp_path):
+    csv_path = tmp_path / "multi.csv"
+    df = pd.DataFrame(
+        [[0, 10], [1, 11]],
+        columns=pd.MultiIndex.from_tuples([("Time", "(s)"), ("Inner", "Diameter")]),
+    )
+    df.to_csv(csv_path, index=False)
+
+    loaded = load_trace(str(csv_path))
+    assert "Time (s)" in loaded.columns
+    assert "Inner Diameter" in loaded.columns
+    assert pd.api.types.is_numeric_dtype(loaded["Time (s)"])
+    assert pd.api.types.is_numeric_dtype(loaded["Inner Diameter"])
+


### PR DESCRIPTION
## Summary
- flatten MultiIndex columns when loading trace CSVs
- update docstring about handling multi-header files
- test loading CSVs with two header rows

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68507933e9d48326aae0149669189bb9