### PR TITLE
Handle multiheader event CSVs

### DIFF
--- a/src/vasoanalyzer/event_loader.py
+++ b/src/vasoanalyzer/event_loader.py
@@ -66,6 +66,12 @@ def load_events(file_path):
 
     df = pd.read_csv(file_path, delimiter=delimiter)
 
+    if isinstance(df.columns, pd.MultiIndex):
+        df.columns = [
+            " ".join(str(part) for part in col if pd.notna(part))
+            for col in df.columns
+        ]
+
     def _looks_like_number_or_time(val: str) -> bool:
         """Return ``True`` if ``val`` resembles a numeric value or timestamp."""
         s = str(val).strip()

--- a/tests/test_event_file_detection.py
+++ b/tests/test_event_file_detection.py
@@ -139,3 +139,18 @@ def test_standardize_headers_additional_aliases():
     std = _standardize_headers(df)
 
     assert list(std.columns) == ["EventLabel", "Time", "DiamBefore"]
+
+
+def test_load_events_multiheader(tmp_path):
+    event_path = tmp_path / "multi.csv"
+    df = pd.DataFrame(
+        [["A", 0.1], ["B", 0.2]],
+        columns=pd.MultiIndex.from_tuples([("Label", ""), ("Time", "(s)")]),
+    )
+    df.to_csv(event_path, index=False)
+
+    labels, times, frames = load_events(str(event_path))
+
+    assert labels == ["A", "B"]
+    assert times == [0.1, 0.2]
+    assert frames is None


### PR DESCRIPTION
## Summary
- flatten multiheader columns when loading events
- add regression test for multiheader event files

## Testing
- `ruff check src tests`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68507b2ab1648326ada53dac36b77a91