### PR TITLE
Implement legacy loader modules

### DIFF
--- a/src/vasoanalyzer/legacy_event_loader.py
+++ b/src/vasoanalyzer/legacy_event_loader.py
@@ -1,0 +1,86 @@
+import os
+import csv
+import logging
+import re
+import numpy as np
+import pandas as pd
+
+from .event_loader import _standardize_headers
+
+log = logging.getLogger(__name__)
+
+
+def is_legacy_event(path: str) -> bool:
+    """Return True if ``path`` appears to be a legacy event table."""
+    name = os.path.basename(path).lower()
+    if "table" in name and "_table" not in name:
+        return True
+    try:
+        with open(path, "r", encoding="utf-8-sig") as f:
+            header = f.readline().lower()
+    except Exception:
+        header = ""
+    if "diameterbefore" in header or "diam before" in header:
+        return False
+    if "event" in header and "label" not in header:
+        return True
+    return False
+
+
+def load_events(file_path: str, trace_df: pd.DataFrame | None = None):
+    """Load legacy events.``
+    Returns labels, times, frames, and diameters (if available)."""
+    log.info("Loading legacy events from %s", file_path)
+    with open(file_path, "r", encoding="utf-8-sig") as f:
+        sample = f.read(1024)
+        try:
+            delimiter = csv.Sniffer().sniff(sample).delimiter
+        except csv.Error:
+            if "," in sample:
+                delimiter = ","
+            elif "\t" in sample:
+                delimiter = "\t"
+            else:
+                delimiter = ";"
+    df = pd.read_csv(file_path, delimiter=delimiter)
+
+    if isinstance(df.columns, pd.MultiIndex):
+        df.columns = [" ".join(str(part) for part in col if pd.notna(part)) for col in df.columns]
+
+    df = _standardize_headers(df)
+
+    def _norm(c: str) -> str:
+        return re.sub(r"[^a-z0-9]", "", c.lower())
+
+    label_col = "EventLabel" if "EventLabel" in df.columns else df.columns[0]
+    time_col = "Time" if "Time" in df.columns else [c for c in df.columns if c != label_col][0]
+
+    labels = df[label_col].astype(str).tolist()
+    time_series = df[time_col]
+    if not pd.api.types.is_numeric_dtype(time_series):
+        numeric = pd.to_numeric(time_series, errors="coerce")
+        if numeric.notna().all():
+            time_series = numeric
+        else:
+            time_series = pd.to_timedelta(time_series, errors="coerce").dt.total_seconds()
+    times = time_series.tolist()
+
+    frame_col = None
+    for c in df.columns:
+        if _norm(c).startswith("frame"):
+            frame_col = c
+            break
+    frames = df[frame_col].astype(int).tolist() if frame_col else None
+
+    diam = None
+    if "DiamBefore" in df.columns:
+        diam = pd.to_numeric(df["DiamBefore"], errors="coerce").astype(float).tolist()
+    elif trace_df is not None:
+        arr_t = trace_df["Time (s)"].values
+        arr_d = trace_df["Inner Diameter"].values
+        diam = [float(arr_d[int(np.argmin(np.abs(arr_t - t)))]) for t in times]
+
+    return labels, times, frames, diam
+
+
+__all__ = ["load_events", "is_legacy_event"]

--- a/src/vasoanalyzer/legacy_trace_loader.py
+++ b/src/vasoanalyzer/legacy_trace_loader.py
@@ -1,0 +1,72 @@
+import os
+import csv
+import re
+import logging
+import pandas as pd
+
+log = logging.getLogger(__name__)
+
+
+def is_legacy_trace(path: str) -> bool:
+    """Return True if ``path`` appears to be a legacy trace file."""
+    name = os.path.basename(path).lower()
+    try:
+        with open(path, "r", encoding="utf-8-sig") as f:
+            header = f.readline().lower()
+    except Exception:
+        header = ""
+    if "inner diameter" in header:
+        return False
+    if "id" in header or "i.d" in header:
+        return True
+    if "mbfa" in name:
+        return True
+    return False
+
+
+def load_trace(file_path: str) -> pd.DataFrame:
+    """Load a legacy trace CSV into a DataFrame."""
+    log.info("Loading legacy trace from %s", file_path)
+    with open(file_path, "r", encoding="utf-8-sig") as f:
+        sample = f.read(1024)
+        try:
+            delimiter = csv.Sniffer().sniff(sample).delimiter
+        except csv.Error:
+            if "," in sample:
+                delimiter = ","
+            elif "\t" in sample:
+                delimiter = "\t"
+            else:
+                delimiter = ";"
+    df = pd.read_csv(file_path, delimiter=delimiter, encoding="utf-8-sig", header=0)
+
+    if isinstance(df.columns, pd.MultiIndex):
+        df.columns = [" ".join(str(part) for part in col if pd.notna(part)) for col in df.columns]
+
+    df = df.dropna(axis=1, how="all")
+
+    def _norm(c: str) -> str:
+        return re.sub(r"[^a-z0-9]", "", c.lower())
+
+    time_col = None
+    diam_col = None
+    for c in df.columns:
+        n = _norm(c)
+        if time_col is None and ("time" in n or n in {"t", "ts"}):
+            time_col = c
+        if diam_col is None and (n == "id" or "diam" in n):
+            diam_col = c
+
+    if time_col is None or diam_col is None:
+        raise ValueError("Legacy trace file missing Time or Diameter columns")
+
+    df = df.rename(columns={time_col: "Time (s)", diam_col: "Inner Diameter"})
+    df = df.loc[:, ["Time (s)", "Inner Diameter"]]
+    df["Time (s)"] = pd.to_numeric(df["Time (s)"], errors="coerce")
+    df["Inner Diameter"] = pd.to_numeric(df["Inner Diameter"], errors="coerce")
+
+    log.info("Loaded legacy trace with %d rows", len(df))
+    return df
+
+
+__all__ = ["load_trace", "is_legacy_trace"]

--- a/src/vasoanalyzer/trace_event_loader.py
+++ b/src/vasoanalyzer/trace_event_loader.py
@@ -4,11 +4,19 @@ import logging
 import numpy as np
 import pandas as pd
 
-from .trace_loader import load_trace
+from .trace_loader import load_trace as modern_load_trace
+from .legacy_trace_loader import (
+    load_trace as legacy_load_trace,
+    is_legacy_trace,
+)
 from .event_loader import (
     load_events,
     find_matching_event_file,
     _standardize_headers,
+)
+from .legacy_event_loader import (
+    load_events as legacy_load_events,
+    is_legacy_event,
 )
 
 
@@ -50,7 +58,10 @@ def load_trace_and_events(trace_path: str, events_path: str | pd.DataFrame | Non
         ``None`` if unavailable) and the diameter at each event time.
     """
     log.info("Loading trace and events for %s", trace_path)
-    df = load_trace(trace_path)
+    if is_legacy_trace(trace_path):
+        df = legacy_load_trace(trace_path)
+    else:
+        df = modern_load_trace(trace_path)
 
     events_df = None
     ev_path = None
@@ -76,7 +87,10 @@ def load_trace_and_events(trace_path: str, events_path: str | pd.DataFrame | Non
     if events_df is not None or (ev_path and os.path.exists(ev_path)):
         if events_df is None:
             events_df = _read_event_dataframe(ev_path)
-            labels, times, frames = load_events(ev_path)
+            if is_legacy_event(ev_path):
+                labels, times, frames, diam = legacy_load_events(ev_path, df)
+            else:
+                labels, times, frames = load_events(ev_path)
         else:
             labels = events_df[events_df.columns[0]].astype(str).tolist()
             if "Time" in events_df.columns:
@@ -92,11 +106,12 @@ def load_trace_and_events(trace_path: str, events_path: str | pd.DataFrame | Non
         log.info("Loaded %d events", len(labels))
 
         arr_t = df["Time (s)"].values
-        if "DiamBefore" in events_df.columns:
-            diam = pd.to_numeric(events_df["DiamBefore"], errors="coerce").astype(float).tolist()
-        else:
-            arr_d = df["Inner Diameter"].values
-            diam = [float(arr_d[int(np.argmin(np.abs(arr_t - t)))]) for t in times]
+        if not diam:
+            if "DiamBefore" in events_df.columns:
+                diam = pd.to_numeric(events_df["DiamBefore"], errors="coerce").astype(float).tolist()
+            else:
+                arr_d = df["Inner Diameter"].values
+                diam = [float(arr_d[int(np.argmin(np.abs(arr_t - t)))]) for t in times]
 
         if frames is None:
             frames = [int(np.argmin(np.abs(arr_t - t))) for t in times]


### PR DESCRIPTION
## Summary
- add `legacy_trace_loader` for old-style trace CSVs
- add `legacy_event_loader` for old event table formats
- use the legacy loaders automatically in `load_trace_and_events`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68508c4244248326843a9a9890c15b95