### PR TITLE
Add diameter visibility toggles

### DIFF
--- a/src/vasoanalyzer/ui/main_window.py
+++ b/src/vasoanalyzer/ui/main_window.py
@@ -107,6 +107,8 @@ class VasoAnalyzerApp(QMainWindow):
         self.pinned_points = []
         self.slider_marker = None
         self.trace_line = None
+        self.od_line = None
+        self.ax2 = None
         # Default time between frames when metadata is unavailable
         self.recording_interval = 0.14  # 140 ms per frame
         self.last_replaced_event = None
@@ -698,6 +700,14 @@ class VasoAnalyzerApp(QMainWindow):
         self.showhide_menu.addAction(evt_tbl)
         self.showhide_menu.addAction(snap_vw)
 
+        # Diameter visibility toggles
+        self.id_toggle_act = QAction("Inner Diameter", self, checkable=True, checked=True)
+        self.od_toggle_act = QAction("Outer Diameter", self, checkable=True, checked=True)
+        self.id_toggle_act.triggered.connect(self.toggle_inner_diameter)
+        self.od_toggle_act.triggered.connect(self.toggle_outer_diameter)
+        self.showhide_menu.addAction(self.id_toggle_act)
+        self.showhide_menu.addAction(self.od_toggle_act)
+
         view_menu.addSeparator()
 
         # 4) Single / Dual
@@ -956,6 +966,18 @@ class VasoAnalyzerApp(QMainWindow):
     def toggle_snapshot_viewer(self, checked: bool):
         self.snapshot_label.setVisible(checked)
         self.slider.setVisible(checked)
+
+    def toggle_inner_diameter(self, checked: bool):
+        if self.trace_line:
+            self.trace_line.set_visible(checked)
+            self.canvas.draw_idle()
+
+    def toggle_outer_diameter(self, checked: bool):
+        if self.od_line:
+            self.od_line.set_visible(checked)
+        if self.ax2:
+            self.ax2.set_visible(checked)
+        self.canvas.draw_idle()
 
 
     def toggle_fullscreen(self):
@@ -2224,6 +2246,8 @@ class VasoAnalyzerApp(QMainWindow):
         t = self.trace_data["Time (s)"]
         d = self.trace_data["Inner Diameter"]
         (self.trace_line,) = self.ax.plot(t, d, "k-", linewidth=1.5)
+        if hasattr(self, "id_toggle_act"):
+            self.trace_line.set_visible(self.id_toggle_act.isChecked())
         self.ax.set_xlabel("Time (s)")
         self.ax.set_ylabel("Inner Diameter (µm)")
         self.ax.grid(True, color=CURRENT_THEME["grid_color"])
@@ -2236,6 +2260,10 @@ class VasoAnalyzerApp(QMainWindow):
             (self.od_line,) = self.ax2.plot(t, od_trace, color="tab:orange", linewidth=1.2)
             self.ax2.set_ylabel("Outer Diameter (µm)")
             self.ax2.tick_params(colors=CURRENT_THEME["text"])
+            if hasattr(self, "od_toggle_act"):
+                vis = self.od_toggle_act.isChecked()
+                self.od_line.set_visible(vis)
+                self.ax2.set_visible(vis)
 
         # Plot events if available
         if self.event_labels and self.event_times:

--- a/tests/test_diameter_toggles.py
+++ b/tests/test_diameter_toggles.py
@@ -1,0 +1,41 @@
+import os
+import pandas as pd
+import matplotlib
+matplotlib.use('Agg')
+from PyQt5.QtWidgets import QApplication
+from vasoanalyzer.ui.main_window import VasoAnalyzerApp
+
+
+def test_diameter_toggle_visibility(tmp_path):
+    os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
+    trace_path = tmp_path / 'trace.csv'
+    df = pd.DataFrame({
+        'Time (s)': [0, 1, 2],
+        'Inner Diameter': [10, 11, 12],
+        'Outer Diameter': [15, 16, 17],
+    })
+    df.to_csv(trace_path, index=False)
+    event_path = tmp_path / 'trace_table.csv'
+    pd.DataFrame({'label': ['A'], 'time': [1]}).to_csv(event_path, index=False)
+
+    app = QApplication.instance() or QApplication([])
+    gui = VasoAnalyzerApp()
+    gui.load_trace_and_events(str(trace_path))
+
+    assert gui.trace_line.get_visible() is True
+    assert gui.od_line.get_visible() is True
+
+    gui.toggle_inner_diameter(False)
+    gui.toggle_outer_diameter(False)
+
+    assert gui.trace_line.get_visible() is False
+    assert gui.od_line.get_visible() is False
+    assert gui.ax2.get_visible() is False
+
+    gui.toggle_inner_diameter(True)
+    gui.toggle_outer_diameter(True)
+
+    assert gui.trace_line.get_visible() is True
+    assert gui.od_line.get_visible() is True
+    assert gui.ax2.get_visible() is True
+    app.quit()


### PR DESCRIPTION
## Summary
- add menu options to toggle Inner and Outer Diameter traces
- toggle visibility of diameter lines in update_plot
- provide slot methods for new actions
- test diameter toggle behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6850bd4ba1448326a4b64592ada8b2a5