### PR TITLE
Add inner diameter toggle button

### DIFF
--- a/src/vasoanalyzer/ui/main_window.py
+++ b/src/vasoanalyzer/ui/main_window.py
@@ -1435,7 +1435,11 @@ class VasoAnalyzerApp(QMainWindow):
             toolbar.insertWidget(visible_buttons[7], data_btn)
 
             # Diameter toggle actions
-            toolbar.insertAction(visible_buttons[7], self.id_toggle_act)
+            id_btn = QToolButton()
+            id_btn.setDefaultAction(self.id_toggle_act)
+            id_btn.setToolTip("Toggle inner diameter visibility")
+            toolbar.insertWidget(visible_buttons[7], id_btn)
+
             toolbar.insertAction(visible_buttons[7], self.od_toggle_act)
 
             # Override Save

--- a/tests/test_diameter_toggles.py
+++ b/tests/test_diameter_toggles.py
@@ -24,8 +24,22 @@ def test_diameter_toggle_visibility(tmp_path):
 
     # Toolbar should include diameter toggle actions
     toolbar_actions = gui.toolbar.actions()
-    assert gui.id_toggle_act in toolbar_actions
-    assert gui.od_toggle_act in toolbar_actions
+    assert any(
+        act is gui.id_toggle_act
+        or (
+            hasattr(act, "defaultWidget")
+            and act.defaultWidget().defaultAction() is gui.id_toggle_act
+        )
+        for act in toolbar_actions
+    )
+    assert any(
+        act is gui.od_toggle_act
+        or (
+            hasattr(act, "defaultWidget")
+            and act.defaultWidget().defaultAction() is gui.od_toggle_act
+        )
+        for act in toolbar_actions
+    )
 
     assert gui.trace_line.get_visible() is True
     assert gui.od_line.get_visible() is True


### PR DESCRIPTION
## Summary
- show/hide inner diameter with a dedicated toolbar button
- update unit tests for new widget insertion

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68516a452c1c8326a90f5e48f25e513c