### PR TITLE
Ensure OD trace remains hidden after toggle

### DIFF
--- a/tests/test_diameter_toggles.py
+++ b/tests/test_diameter_toggles.py
@@ -58,3 +58,43 @@ def test_diameter_toggle_visibility(tmp_path):
     assert gui.od_line.get_visible() is True
     assert gui.ax2.get_visible() is True
     app.quit()
+
+
+def test_od_toggle_persists_after_update(tmp_path):
+    """Outer diameter should remain hidden after update_plot when toggled off."""
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+    trace_path = tmp_path / "trace.csv"
+    df = pd.DataFrame(
+        {
+            "Time (s)": [0, 1, 2],
+            "Inner Diameter": [10, 11, 12],
+            "Outer Diameter": [15, 16, 17],
+        }
+    )
+    df.to_csv(trace_path, index=False)
+
+    event_path = tmp_path / "trace_table.csv"
+    pd.DataFrame({"label": ["A"], "time": [1]}).to_csv(event_path, index=False)
+
+    app = QApplication.instance() or QApplication([])
+    gui = VasoAnalyzerApp()
+    gui.load_trace_and_events(str(trace_path))
+
+    # Simulate user clicking the OD toggle
+    gui.od_toggle_act.setChecked(False)
+
+    assert gui.od_line.get_visible() is False
+    assert gui.ax2.get_visible() is False
+
+    # Updating the plot should respect the toggle state
+    gui.update_plot()
+    assert gui.od_line.get_visible() is False
+    assert gui.ax2.get_visible() is False
+
+    gui.od_toggle_act.setChecked(True)
+    gui.update_plot()
+    assert gui.od_line.get_visible() is True
+    assert gui.ax2.get_visible() is True
+
+    app.quit()


### PR DESCRIPTION
## Summary
- add regression test to confirm that hiding the OD trace persists after `update_plot`

## Testing
- `pytest tests/test_diameter_toggles.py::test_od_toggle_persists_after_update -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685173d5e8ec83269ffcea805627b676