### PR TITLE
Fix axis settings toolbar action

### DIFF
--- a/src/vasoanalyzer/ui/main_window.py
+++ b/src/vasoanalyzer/ui/main_window.py
@@ -1355,7 +1355,7 @@ class VasoAnalyzerApp(QMainWindow):
             axes_btn.setIcon(QIcon(self.icon_path("Customize:edit_axis_ranges.svg")))
             axes_btn.triggered.disconnect()
             axes_btn.triggered.connect(
-                lambda c=canvas: self.open_axis_settings_dialog_for(c.figure.axes[0], c)
+                lambda checked=False, c=canvas: self.open_axis_settings_dialog_for(c.figure.axes[0], c)
             )
 
             # Inject custom "Aa" button


### PR DESCRIPTION
## Summary
- fix axis settings dialog callback in toolbar

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68518232f8d88326894d82c52d34b7a1