### PR TITLE
Fix missing QSplitter import

### DIFF
--- a/src/vasoanalyzer/ui/main_window.py
+++ b/src/vasoanalyzer/ui/main_window.py
@@ -42,6 +42,7 @@ from PyQt5.QtWidgets import (
     QDockWidget,
     QTreeWidget,
     QTreeWidgetItem,
+    QSplitter,
     QStyle,
 )
 


### PR DESCRIPTION
## Summary
- fix crash in dual view window by importing `QSplitter`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas, numpy, matplotlib)*

------
https://chatgpt.com/codex/tasks/task_e_6851a9644b3c8326875ff6d2de9b00a5