### PR TITLE
Add recent project clearing and drag‑drop tests

### DIFF
--- a/src/vasoanalyzer/ui/main_window.py
+++ b/src/vasoanalyzer/ui/main_window.py
@@ -630,6 +630,10 @@ class VasoAnalyzerApp(QMainWindow):
         open_act.triggered.connect(self.open_project_file)
         proj_menu.addAction(open_act)
 
+        # Recent Projects submenu
+        self.recent_projects_menu = proj_menu.addMenu("Recent Projects ▶")
+        self.build_recent_projects_menu()
+
         save_act = QAction("Save Project", self)
         save_act.triggered.connect(self.save_project_file)
         proj_menu.addAction(save_act)
@@ -895,6 +899,25 @@ class VasoAnalyzerApp(QMainWindow):
         clear_action.triggered.connect(self.clear_recent_files)
         self.recent_menu.addAction(clear_action)
 
+    def build_recent_projects_menu(self):
+        self.recent_projects_menu.clear()
+
+        if not self.recent_projects:
+            self.recent_projects_menu.addAction("No recent projects").setEnabled(False)
+            return
+
+        for path in self.recent_projects:
+            label = os.path.basename(path)
+            action = QAction(label, self)
+            action.setToolTip(path)
+            action.triggered.connect(partial(self.open_recent_project, path))
+            self.recent_projects_menu.addAction(action)
+
+        self.recent_projects_menu.addSeparator()
+        clear_action = QAction("Clear Recent Projects", self)
+        clear_action.triggered.connect(self.clear_recent_projects)
+        self.recent_projects_menu.addAction(clear_action)
+
 
     def open_preferences_dialog(self):
         QMessageBox.information(
@@ -1002,6 +1025,33 @@ class VasoAnalyzerApp(QMainWindow):
             self.recent_projects = [path] + self.recent_projects[:4]
             settings = QSettings("TykockiLab", "VasoAnalyzer")
             settings.setValue("recentProjects", self.recent_projects)
+        self.build_recent_projects_menu()
+
+    def save_recent_projects(self):
+        QSettings("TykockiLab", "VasoAnalyzer").setValue(
+            "recentProjects", self.recent_projects
+        )
+
+    def clear_recent_projects(self):
+        self.recent_projects = []
+        self.save_recent_projects()
+        self.build_recent_projects_menu()
+
+    def open_recent_project(self, path):
+        self.current_project = open_project(path)
+        self.apply_ui_state(getattr(self.current_project, "ui_state", None))
+        self.refresh_project_tree()
+        self.project_dock.show()
+        self.statusBar().showMessage(
+            f"\u2713 Project loaded: {self.current_project.name}", 3000
+        )
+        self.update_recent_projects(path)
+        if (
+            self.current_project.experiments
+            and self.current_project.experiments[0].samples
+        ):
+            first_sample = self.current_project.experiments[0].samples[0]
+            self.load_sample_into_view(first_sample)
 
     def check_for_updates_at_startup(self):
         latest = check_for_new_version(f"v{APP_VERSION}")

--- a/tests/test_drag_drop_and_recent.py
+++ b/tests/test_drag_drop_and_recent.py
@@ -1,0 +1,55 @@
+import os
+import matplotlib
+matplotlib.use('Agg')
+from PyQt5.QtWidgets import QApplication, QDropEvent
+from PyQt5.QtCore import Qt, QMimeData, QUrl, QPoint
+
+from vasoanalyzer.ui.main_window import VasoAnalyzerApp
+from vasoanalyzer.project import Project, Experiment, save_project
+
+
+def create_project(path):
+    proj = Project(name="P", experiments=[Experiment(name="E")])
+    save_project(proj, path)
+    return path
+
+
+def build_drop_event(path):
+    mime = QMimeData()
+    mime.setUrls([QUrl.fromLocalFile(str(path))])
+    return QDropEvent(QPoint(0, 0), Qt.CopyAction, mime, Qt.LeftButton, Qt.NoModifier)
+
+
+def test_drop_vaso_loads_project(tmp_path):
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    proj_path = create_project(tmp_path / "test.vaso")
+
+    app = QApplication.instance() or QApplication([])
+    gui = VasoAnalyzerApp()
+
+    event = build_drop_event(proj_path)
+    gui.dropEvent(event)
+
+    assert gui.current_project is not None
+    assert os.path.samefile(gui.current_project.path, str(proj_path))
+    app.quit()
+
+
+def test_clear_recent_lists(tmp_path):
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    proj_path = create_project(tmp_path / "recent.vaso")
+
+    app = QApplication.instance() or QApplication([])
+    gui = VasoAnalyzerApp()
+
+    gui.update_recent_projects(str(proj_path))
+    gui.recent_files = ["f1.csv", "f2.csv"]
+    gui.save_recent_files()
+
+    gui.clear_recent_files()
+    gui.clear_recent_projects()
+
+    settings = gui.settings
+    assert settings.value("recentFiles") == []
+    assert settings.value("recentProjects") == []
+    app.quit()


### PR DESCRIPTION
## Summary
- add recent projects submenu
- allow clearing recent projects
- update menu after project updates
- test drag-drop of .vaso projects and clearing recent lists

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6851bc4f38508326b046a8f3cb05e8bc