### PR TITLE
Enable per-sample UI state persistence

### DIFF
--- a/src/vasoanalyzer/project.py
+++ b/src/vasoanalyzer/project.py
@@ -27,6 +27,7 @@ class SampleN:
     column: Optional[str] = None
     trace_data: Optional[pd.DataFrame] = None
     events_data: Optional[pd.DataFrame] = None
+    ui_state: Optional[dict] = None
 
 
 @dataclass
@@ -95,6 +96,7 @@ def sample_from_dict(data: dict) -> SampleN:
         column=data.get("column"),
         trace_data=trace_data,
         events_data=events_data,
+        ui_state=data.get("ui_state"),
     )
 
 

--- a/src/vasoanalyzer/ui/main_window.py
+++ b/src/vasoanalyzer/ui/main_window.py
@@ -222,6 +222,8 @@ class VasoAnalyzerApp(QMainWindow):
     def save_project_file(self):
         if self.current_project and self.current_project.path:
             self.current_project.ui_state = self.gather_ui_state()
+            if self.current_sample:
+                self.current_sample.ui_state = self.gather_sample_state()
             save_project_file(self.current_project)
             self.update_recent_projects(self.current_project.path)
             self.statusBar().showMessage("\u2713 Project saved", 3000)
@@ -238,6 +240,8 @@ class VasoAnalyzerApp(QMainWindow):
             if not path.endswith(".vaso"):
                 path += ".vaso"
             self.current_project.ui_state = self.gather_ui_state()
+            if self.current_sample:
+                self.current_sample.ui_state = self.gather_sample_state()
             save_project_file(self.current_project, path)
             self.update_recent_projects(path)
             self.statusBar().showMessage("\u2713 Project saved", 3000)
@@ -272,6 +276,8 @@ class VasoAnalyzerApp(QMainWindow):
     def on_tree_item_clicked(self, item, _):
         obj = item.data(0, Qt.UserRole)
         if isinstance(obj, SampleN):
+            if self.current_sample and self.current_sample is not obj:
+                self.current_sample.ui_state = self.gather_sample_state()
             self.current_sample = obj
             parent = item.parent()
             self.current_experiment = parent.data(0, Qt.UserRole) if parent else None
@@ -293,6 +299,9 @@ class VasoAnalyzerApp(QMainWindow):
     def load_sample_into_view(self, sample: SampleN):
         """Load a sample's trace and events into the main view."""
         log.info("Loading sample %s", sample.name)
+        if self.current_sample and self.current_sample is not sample:
+            self.current_sample.ui_state = self.gather_sample_state()
+        self.current_sample = sample
         try:
             if sample.trace_data is not None:
                 trace = sample.trace_data.copy()
@@ -343,6 +352,7 @@ class VasoAnalyzerApp(QMainWindow):
         self.update_plot()
         self.compute_frame_trace_indices()
         self.load_project_events(labels, times, frames, diam, od)
+        self.apply_sample_state(getattr(sample, "ui_state", None))
         log.info("Sample loaded with %d events", len(labels))
 
     def open_samples_in_new_windows(self, samples):
@@ -361,6 +371,7 @@ class VasoAnalyzerApp(QMainWindow):
                 column=s.column,
                 trace_data=s.trace_data.copy() if s.trace_data is not None else None,
                 events_data=s.events_data.copy() if s.events_data is not None else None,
+                ui_state=s.ui_state.copy() if s.ui_state is not None else None,
             )
             win.load_sample_into_view(sample_copy)
             self.compare_windows.append(win)
@@ -392,6 +403,7 @@ class VasoAnalyzerApp(QMainWindow):
                         column=s.column,
                         trace_data=s.trace_data.copy() if s.trace_data is not None else None,
                         events_data=s.events_data.copy() if s.events_data is not None else None,
+                        ui_state=s.ui_state.copy() if s.ui_state is not None else None,
                     )
                     view.load_sample_into_view(sample_copy)
                     self.views.append(view)
@@ -3602,6 +3614,14 @@ class VasoAnalyzerApp(QMainWindow):
             "axis_ylim": list(self.ax.get_ylim()),
         }
 
+    def gather_sample_state(self):
+        return {
+            "axis_xlim": list(self.ax.get_xlim()),
+            "axis_ylim": list(self.ax.get_ylim()),
+            "table_fontsize": self.event_table.font().pointSize(),
+            "event_table_data": list(self.event_table_data),
+        }
+
     def apply_ui_state(self, state):
         if not state:
             return
@@ -3617,10 +3637,28 @@ class VasoAnalyzerApp(QMainWindow):
             self.ax.set_ylim(state["axis_ylim"])
         self.canvas.draw_idle()
 
+    def apply_sample_state(self, state):
+        if not state:
+            return
+        if "event_table_data" in state:
+            self.event_table_data = state["event_table_data"]
+            self.populate_table()
+        if "axis_xlim" in state:
+            self.ax.set_xlim(state["axis_xlim"])
+        if "axis_ylim" in state:
+            self.ax.set_ylim(state["axis_ylim"])
+        if "table_fontsize" in state:
+            font = self.event_table.font()
+            font.setPointSize(state["table_fontsize"])
+            self.event_table.setFont(font)
+        self.canvas.draw_idle()
+
     def closeEvent(self, event):
         if self.current_project and self.current_project.path:
             try:
                 self.current_project.ui_state = self.gather_ui_state()
+                if self.current_sample:
+                    self.current_sample.ui_state = self.gather_sample_state()
                 save_project_file(self.current_project)
             except Exception as e:
                 log.error("Failed to auto-save project:\n%s", e)

--- a/tests/test_sample_ui_state.py
+++ b/tests/test_sample_ui_state.py
@@ -1,0 +1,32 @@
+import os
+import pandas as pd
+import matplotlib
+matplotlib.use('Agg')
+from PyQt5.QtWidgets import QApplication
+
+from vasoanalyzer.ui.main_window import VasoAnalyzerApp
+from vasoanalyzer.project import SampleN
+
+
+def test_sample_state_persistence_and_dual_view(tmp_path):
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    df_trace = pd.DataFrame({"Time (s)": [0, 1], "Inner Diameter": [10, 11]})
+    df_events = pd.DataFrame({"label": ["A"], "time": [1]})
+
+    s1 = SampleN(name="N1", trace_data=df_trace, events_data=df_events)
+    s2 = SampleN(name="N2", trace_data=df_trace, events_data=df_events)
+
+    app = QApplication.instance() or QApplication([])
+    gui = VasoAnalyzerApp()
+
+    gui.load_sample_into_view(s1)
+    gui.ax.set_xlim(1, 2)
+    gui.load_sample_into_view(s2)
+
+    assert s1.ui_state["axis_xlim"] == [1.0, 2.0]
+
+    gui.open_samples_in_dual_view([s1, s2])
+    view1, view2 = gui.dual_window.views
+    assert list(view1.ax.get_xlim()) == [1.0, 2.0]
+
+    app.quit()


### PR DESCRIPTION
## Summary
- store a new `ui_state` dict for each `SampleN`
- capture per-sample plot and table settings when switching samples or saving projects
- restore sample state when reopening or when using dual view
- copy sample `ui_state` when opening new windows
- add regression test for sample UI state persistence

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6851d39c0f6483269b13c716e422bc79