### PR TITLE
Fix pin placement with outer diameter

### DIFF
--- a/src/vasoanalyzer/ui/main_window.py
+++ b/src/vasoanalyzer/ui/main_window.py
@@ -2649,7 +2649,10 @@ class VasoAnalyzerApp(QMainWindow):
 
     # [G] ========================= PIN INTERACTION LOGIC ================================
     def handle_click_on_plot(self, event):
-        if event.inaxes != self.ax:
+        valid_axes = [self.ax]
+        if self.ax2:
+            valid_axes.append(self.ax2)
+        if event.inaxes not in valid_axes:
             return
 
         x = event.xdata


### PR DESCRIPTION
## Summary
- allow pinning when clicking on the secondary axis

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68520a18c79083269716b5151576e578