### PR TITLE
Fix Zoom Out button

### DIFF
--- a/src/vasoanalyzer/ui/main_window.py
+++ b/src/vasoanalyzer/ui/main_window.py
@@ -1526,7 +1526,7 @@ class VasoAnalyzerApp(QMainWindow):
             zoom_out_btn = QToolButton()
             zoom_out_btn.setIcon(QIcon(self.icon_path("ZoomOut.svg")))
             zoom_out_btn.setToolTip("Zoom Out")
-            zoom_out_btn.clicked.connect(self.zoom_out)
+            zoom_out_btn.clicked.connect(lambda: self.zoom_out())
             toolbar.insertWidget(visible_buttons[5], zoom_out_btn)
 
             layout_btn = visible_buttons[5]


### PR DESCRIPTION
## Summary
- ensure Zoom Out button calls `zoom_out()` without passing the click state

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6852afbd9f988326be63ef9e0be1b11e